### PR TITLE
build: fix to open with open-source osal layer

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/bash -x
 #
-# Copyright (C) 2017 Wind River Systems, Inc. All Rights Reserved.
+# Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -65,9 +65,9 @@ cd ..
 rm -rf libwebsockets
 
 # operating system abstraction layer
-git clone ssh://git@github.com/Wind-River/device-cloud-osal.git device-cloud-osal
+git clone https://github.com/Wind-River/device-cloud-osal.git device-cloud-osal
 cd device-cloud-osal
-cmake -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX:PATH="$DEPS_DIR" -DSOAL_THREAD_SUPPORT:BOOL=$THREAD_SUPPORT -DOSAL_WRAP:BOOL=ON .
+cmake -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX:PATH="$DEPS_DIR" -DOSAL_THREAD_SUPPORT:BOOL=$THREAD_SUPPORT -DOSAL_WRAP:BOOL=ON .
 make
 make install
 cd ..

--- a/src/api/plugin/tr50/tr50.c
+++ b/src/api/plugin/tr50/tr50.c
@@ -34,14 +34,6 @@
 #define TR50_MQTT_QOS                        1
 /** @brief Maximum concurrent file transfers */
 #define TR50_FILE_TRANSFER_MAX               10u
-/** @brief Default value for ssl verify host */
-#define TR50_DEFAULT_SSL_VERIFY_HOST         2u
-/** @brief Default value for ssl verify peer */
-#define TR50_DEFAULT_SSL_VERIFY_PEER         1u
-/** @brief File transfer progress interval in seconds */
-#define TR50_FILE_TRANSFER_PROGRESS_INTERVAL 5.0
-/** @brief Extension for temporary downloaded file */
-#define TR50_DOWNLOAD_EXTENSION              ".part"
 /** @brief Time interval in seconds to check file
  *         transfer queue */
 #define TR50_FILE_QUEUE_CHECK_INTERVAL       30 * IOT_MILLISECONDS_IN_SECOND /* 30 seconds */
@@ -50,6 +42,17 @@
 #define TR50_FILE_TRANSFER_EXPIRY_TIME       1 * IOT_MINUTES_IN_HOUR * \
                                              IOT_SECONDS_IN_MINUTE * \
                                              IOT_MILLISECONDS_IN_SECOND /* 1 hour */
+
+#ifdef IOT_THREAD_SUPPORT
+/** @brief File transfer progress interval in seconds */
+#define TR50_FILE_TRANSFER_PROGRESS_INTERVAL 5.0
+/** @brief Default value for ssl verify host */
+#define TR50_DEFAULT_SSL_VERIFY_HOST         2u
+/** @brief Default value for ssl verify peer */
+#define TR50_DEFAULT_SSL_VERIFY_PEER         1u
+/** @brief Extension for temporary downloaded file */
+#define TR50_DOWNLOAD_EXTENSION              ".part"
+#endif /* ifdef IOT_THREAD_SUPPORT */
 
 /** @brief structure containing informaiton about a file transfer */
 struct tr50_file_transfer
@@ -454,6 +457,7 @@ static IOT_SECTION iot_status_t tr50_file_request_send(
 	const iot_file_transfer_t* file_transfer,
 	const iot_options_t *options );
 
+#ifdef IOT_THREAD_SUPPORT
 /**
  * @brief a thread to perform file transfer
  *
@@ -499,6 +503,7 @@ static IOT_SECTION int tr50_file_progress_old(
 	void *user_data,
 	double down_total, double down_now,
 	double up_total, double up_now );
+#endif /* ifdef IOT_THREAD_SUPPORT */
 
 /**
  * @brief checks file transfer queue and execute those which need retrying
@@ -1348,6 +1353,7 @@ iot_status_t tr50_file_request_send(
 	return result;
 }
 
+#ifdef IOT_THREAD_SUPPORT
 OS_THREAD_DECL tr50_file_transfer(
 	void* arg )
 {
@@ -1763,6 +1769,7 @@ int tr50_file_progress_old(
 		(curl_off_t)down_total, (curl_off_t)down_now,
 		(curl_off_t)up_total, (curl_off_t)up_now );
 }
+#endif /* ifdef IOT_THREAD_SUPPORT */
 
 void tr50_file_queue_check(
 	struct tr50_data *data )
@@ -1774,6 +1781,7 @@ void tr50_file_queue_check(
 			now - data->file_queue_last_checked >=
 			TR50_FILE_QUEUE_CHECK_INTERVAL )
 		{
+#ifdef IOT_THREAD_SUPPORT
 			iot_uint8_t i = 0u;
 			for ( i= 0u;
 				i < data->file_transfer_count;
@@ -1792,6 +1800,7 @@ void tr50_file_queue_check(
 						transfer->retry_time = 0u;
 				}
 			}
+#endif /* ifdef IOT_THREAD_SUPPORT */
 			data->file_queue_last_checked = now;
 		}
 	}
@@ -2119,6 +2128,7 @@ void tr50_on_message(
 										}
 									}
 
+#ifdef IOT_THREAD_SUPPORT
 									if ( found_transfer )
 									{
 										os_thread_t thread;
@@ -2129,6 +2139,7 @@ void tr50_on_message(
 												"Failed to create a thread to transfer "
 												"file for message #%u", msg_id );
 									}
+#endif /* ifdef IOT_THREAD_SUPPORT */
 								}
 							}
 						}

--- a/src/device-manager/device_manager_file.h
+++ b/src/device-manager/device_manager_file.h
@@ -2,7 +2,7 @@
  * @file
  * @brief Header file for handling file operations
  *
- * @copyright Copyright (C) 2016-2017 Wind River Systems, Inc. All Rights Reserved.
+ * @copyright Copyright (C) 2016-2018 Wind River Systems, Inc. All Rights Reserved.
  *
  * @license Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,15 +121,19 @@ struct device_manager_file_transfer
 	iot_timestamp_t expiry_time;
 	/** @brief Time when a paused transfer session is resumed */
 	iot_timestamp_t resume_time;
+#ifdef IOT_THREAD_SUPPORT
 	/** @brief Mutex protecting file transer data */
 	os_thread_mutex_t *file_transfer_mutex;
+#endif /* ifdef IOT_THREAD_SUPPORT */
 };
 
 /** @brief Structure containing information for file io */
 struct device_manager_file_io_info
 {
+#ifdef IOT_THREAD_SUPPORT
 	/** @brief Mutex protecting file transer data */
 	os_thread_mutex_t file_transfer_mutex;
+#endif /* ifdef IOT_THREAD_SUPPORT */
 	/** @brief Number of file transfers in progress */
 	size_t file_transfer_count;
 	/** @brief Structure holding proxy server information */

--- a/src/device-manager/device_manager_main.c
+++ b/src/device-manager/device_manager_main.c
@@ -1,7 +1,7 @@
 /**
  * @brief Source file for the device-manager app.
  *
- * @copyright Copyright (C) 2016-2017 Wind River Systems, Inc. All Rights Reserved.
+ * @copyright Copyright (C) 2016-2018 Wind River Systems, Inc. All Rights Reserved.
  *
  * @license Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1171,7 +1171,7 @@ iot_status_t device_manager_initialize( const char *app_path,
 
 #if defined( IOT_THREAD_SUPPORT ) && !defined( NO_FILEIO_SUPPORT )
 			if ( os_thread_mutex_create( file_transfer_lock ) != OS_STATUS_SUCCESS )
-				IOT_LOG( iot_lib, IOT_LOG_ERROR, "%s", "Failed to create file_transfer_mutex" );
+				IOT_LOG( iot_lib, IOT_LOG_ERROR, "%s", "Failed to create lock for file transfer" );
 #endif /* if defined( IOT_THREAD_SUPPORT ) && !defined( NO_FILEIO_SUPPORT ) */
 			if ( device_manager_actions_register( device_manager ) != IOT_STATUS_SUCCESS )
 				IOT_LOG( iot_lib, IOT_LOG_ERROR, "%s",	"Failed to register device-manager actions" );

--- a/test/mock/mock_osal.c
+++ b/test/mock/mock_osal.c
@@ -89,6 +89,7 @@ os_status_t __wrap_os_system_run_wait(
 	size_t out_len[2u],
 	os_millisecond_t max_time_out );
 os_bool_t __wrap_os_terminal_vt100_support( os_file_t stream );
+#ifdef IOT_THREAD_SUPPORT
 os_status_t __wrap_os_thread_condition_broadcast( os_thread_condition_t *cond );
 os_status_t __wrap_os_thread_condition_create( os_thread_condition_t *cond );
 os_status_t __wrap_os_thread_condition_destroy( os_thread_condition_t *cond );
@@ -112,6 +113,7 @@ os_status_t __wrap_os_thread_rwlock_read_unlock( os_thread_rwlock_t *lock );
 os_status_t __wrap_os_thread_rwlock_write_lock( os_thread_rwlock_t *lock );
 os_status_t __wrap_os_thread_rwlock_write_unlock( os_thread_rwlock_t *lock );
 os_status_t __wrap_os_thread_wait( os_thread_t *thread );
+#endif /* ifdef IOT_THREAD_SUPPORT */
 os_status_t __wrap_os_time( os_timestamp_t *time_stamp, os_bool_t *up_time );
 int __wrap_os_vfprintf( os_file_t stream, const char *format, va_list args )
 	__attribute__((format(printf,2,0)));
@@ -710,6 +712,7 @@ os_bool_t __wrap_os_terminal_vt100_support( os_file_t stream )
 	return mock_type( os_bool_t );
 }
 
+#ifdef IOT_THREAD_SUPPORT
 os_status_t __wrap_os_thread_condition_broadcast( os_thread_condition_t *cond )
 {
 	/* ensure this function is called meeting pre-requirements */
@@ -852,6 +855,7 @@ os_status_t __wrap_os_thread_wait( os_thread_t *thread )
 	assert_non_null( thread );
 	return OS_STATUS_FAILURE;
 }
+#endif /* ifdef IOT_THREAD_SUPPORT */
 
 int __wrap_os_printf( const char *format, ... )
 {


### PR DESCRIPTION
This patch contains a fix to the build script to build using the
open-source OSAL layer instead of trying to use one in a private
repository with a private key.

Signed-off-by: Keith Holman <keith.holman@windriver.com>