### PR TITLE
Limit fix

### DIFF
--- a/src/api/plugin/tr50/tr50.c
+++ b/src/api/plugin/tr50/tr50.c
@@ -26,6 +26,10 @@
 #include <os.h>
 #include <curl/curl.h>
 
+#ifdef IOT_STACK_ONLY
+#define TR50_IN_BUFFER_SIZE                 1024u
+#endif /* ifdef IOT_STACK_ONLY */
+
 /** @brief Maximum length for a "thingkey" */
 #define TR50_THING_KEY_MAX_LEN               ( IOT_ID_MAX_LEN * 2 ) + 1u
 /** @brief number of seconds to show "Connection loss message" */
@@ -1834,7 +1838,9 @@ void tr50_on_message(
 	int UNUSED(qos),
 	iot_bool_t UNUSED(retain) )
 {
-	char buf[1024u];
+#ifdef IOT_STACK_ONLY
+	char buf[TR50_IN_BUFFER_SIZE];
+#endif
 	struct tr50_data *const data = (struct tr50_data *)(user_data);
 	iot_json_decoder_t *json;
 	const iot_json_item_t *root;
@@ -1848,7 +1854,11 @@ void tr50_on_message(
 	IOT_LOG( data->lib, IOT_LOG_TRACE,
 		"-->received: %.*s", (int)payload_len, (const char *)payload );
 
-	json = iot_json_decode_initialize( buf, 1024u, 0u );
+#ifdef IOT_STACK_ONLY
+	json = iot_json_decode_initialize( buf, TR50_IN_BUFFER_SIZE, 0u );
+#else
+	json = iot_json_decode_initialize( NULL, 0u, IOT_JSON_FLAG_DYNAMIC );
+#endif
 	if ( data && json &&
 		iot_json_decode_parse( json, payload, payload_len, &root,
 			NULL, 0u ) == IOT_STATUS_SUCCESS )

--- a/src/api/plugin/tr50/tr50.c
+++ b/src/api/plugin/tr50/tr50.c
@@ -857,6 +857,7 @@ iot_status_t tr50_check_mailbox(
 		iot_json_encode_object_start( req_json, "cmd" );
 		iot_json_encode_string( req_json, "command", "mailbox.check" );
 		iot_json_encode_object_start( req_json, "params" );
+		iot_json_encode_integer( req_json, "limit", IOT_ACTION_QUEUE_MAX );
 		iot_json_encode_bool( req_json, "autoComplete", IOT_FALSE );
 		iot_json_encode_object_end( req_json );
 		iot_json_encode_object_end( req_json );


### PR DESCRIPTION
This patchset contains 2 fixes

1) sets the limit to the number of internal actions we can handle in the mailbox.check message (note this parameter is currently ignored by the cloud), but in the future will work.
2) dynamically allows a read buffer for incoming messages.