### PR TITLE
tr50: executing non-cloud based actions causes segfault

### DIFF
--- a/src/api/plugin/tr50/tr50.c
+++ b/src/api/plugin/tr50/tr50.c
@@ -525,7 +525,7 @@ iot_status_t tr50_action_complete(
 		const char *source = iot_action_request_source( request );
 
 		result = IOT_STATUS_SUCCESS;
-		if ( os_strncmp( source, "tr50", 4 ) == 0 )
+		if ( source && os_strncmp( source, "tr50", 4 ) == 0 )
 		{
 			const char *req_id;
 			result = iot_action_request_option_get(


### PR DESCRIPTION
closes: #57

The tr50 plug-in code worked assuming all actions were initiated by the
cloud.  This is not the case, by call iot_action_execute directly one is
able to similate and action locally.  However, doing this was causing a
seg fault as the action was trying to update the cloud with a result.
This patch provides a fix that disables this update as intended.

Signed-off-by: Keith Holman <keith.holman@windriver.com>