### PR TITLE
api: fix memory leaks caused by paho

### DIFF
--- a/src/api/iot_mqtt.c
+++ b/src/api/iot_mqtt.c
@@ -506,6 +506,8 @@ int iot_mqtt_on_message(
 		(size_t)message->payloadlen, message->qos, message->retained );
 
 	/* message succesfully handled */
+	MQTTClient_freeMessage( &message );
+	MQTTClient_free( topic );
 	return (int)IOT_TRUE;
 }
 #endif /* else IOT_MQTT_MOSQUITTO */


### PR DESCRIPTION
Memory being allocated by paho mqtt client library was not being free'd
after being used.  This patch adds the required free commands to ensure
that memory is free'd after use.

Signed-off-by: Keith Holman <keith.holman@windriver.com>