### PR TITLE
api: fixes to plug-in function signatures

### DIFF
--- a/src/api/public/iot_plugin.h
+++ b/src/api/public/iot_plugin.h
@@ -117,7 +117,7 @@ typedef iot_bool_t (*iot_plugin_info_fptr)(
 	iot_version_t *min,
 	iot_version_t *max );
 /** @brief defines the signature for the function to load the plugin */
-typedef void (*iot_plugin_load_fptr)(
+typedef iot_bool_t (*iot_plugin_load_fptr)(
 	iot_plugin_t *p );
 /**
  * @brief internal structure used to point to various functions within the plug-in
@@ -163,13 +163,14 @@ struct iot_plugin
 #define IOT_PLUGIN_NAME(x,x2,o,v,y,z) \
 	IOT_API iot_bool_t x ## _info( const char **name, iot_int32_t *order,\
 		iot_version_t *ver, iot_version_t *min, iot_version_t *max ); \
-	IOT_API void x ## _load( iot_plugin_t *p ); \
+	IOT_API iot_bool_t x ## _load( iot_plugin_t *p ); \
 	iot_bool_t x ## _info( const char **name, iot_int32_t *order,\
 		iot_version_t *ver, iot_version_t *min, iot_version_t *max ) {\
 		if (name) *name = (#x2); if (order) *order = (o);\
 		if (ver) *ver = (v); if (min) *min = (y); if (max) *max = (z);\
-		return IOT_TRUE; }\
-	void x ## _load( iot_plugin_t *p ) {\
+		return IOT_TRUE;\
+	}\
+	iot_bool_t x ## _load( iot_plugin_t *p ) {\
 		p->disable = &( x2 ## _disable );\
 		p->enable = &( x2 ## _enable );\
 		p->execute = &( x2 ## _execute );\
@@ -179,6 +180,7 @@ struct iot_plugin
 		p->data = NULL;\
 		p->name = #x2;\
 		p->handle = NULL;\
+		return IOT_TRUE;\
 	}
 
 /**


### PR DESCRIPTION
The internal macro for generating plug-in functions expected the _load
function to return an "iot_bool_t".  However, when not using a plug-in the
macro was generating code with a function that returns a "void".  This
patch updates the code so that it is all consistent.

Signed-off-by: Keith Holman <keith.holman@windriver.com>