### PR TITLE
device-manager: publish api version to api_version

### DIFF
--- a/src/device-manager/device_manager_main.c
+++ b/src/device-manager/device_manager_main.c
@@ -1300,8 +1300,7 @@ int device_manager_main( int argc, char *argv[] )
 
 				iot_attribute_publish_string(
 					APP_DATA.iot_lib, NULL, NULL,
-					IOT_PRODUCT_SHORT "_version",
-					iot_version_str() );
+					"api_version", iot_version_str() );
 
 				os_memzero( &os, sizeof( os_system_info_t ) );
 				if ( os_system_info( &os ) == OS_STATUS_SUCCESS )


### PR DESCRIPTION
Previously the API version was being published to an attribute named:
`device-cloud_version`, however, this was not in the thing definition.
The thing definition contained an item named: `hdc_version`, but the
project is in the process of removing the `hdc` name.  This patch
updates the attribute to be published as the property `api_version` so
that the property is now name agnostic.

Signed-off-by: Keith Holman <keith.holman@windriver.com>