### PR TITLE
device-manager: use new os_env_expand function

### DIFF
--- a/src/device-manager/device_manager_main.c
+++ b/src/device-manager/device_manager_main.c
@@ -832,7 +832,7 @@ iot_status_t device_manager_config_read(
 		iot_directory_name_get( IOT_DIR_RUNTIME,
 			device_manager_info->runtime_dir,
 			PATH_MAX );
-		os_env_expand( device_manager_info->runtime_dir, PATH_MAX );
+		os_env_expand( device_manager_info->runtime_dir, 0u, PATH_MAX );
 		device_manager_info->runtime_dir[PATH_MAX] = '\0';
 		IOT_LOG( NULL, IOT_LOG_INFO,
 			"  * Setting default runtime dir to %s",
@@ -950,7 +950,7 @@ iot_status_t device_manager_config_read(
 						os_strncpy(device_manager_info->runtime_dir,
 							temp, temp_len );
 
-						os_env_expand( device_manager_info->runtime_dir, PATH_MAX );
+						os_env_expand( device_manager_info->runtime_dir, 0u, PATH_MAX );
 						device_manager_info->runtime_dir[ temp_len ] = '\0';
 						IOT_LOG( NULL, IOT_LOG_INFO,
 							"  * runtime dir = %s", device_manager_info->runtime_dir );

--- a/src/utilities/app_path.c
+++ b/src/utilities/app_path.c
@@ -72,7 +72,7 @@ size_t app_path_make_absolute( char *path, size_t path_max,
 	if ( path && *path != '\0' )
 	{
 		/* convert any environment variables in the path */
-		result = os_env_expand( path, path_max );
+		result = os_env_expand( path, 0u, path_max );
 		if ( result < path_max )
 		{
 			result = os_strlen( path );


### PR DESCRIPTION
The `os_env_expand` function changed in the OSAL layer to accept an
additional parameter.  This patch updates the build to use the new
signature.

Signed-off-by: Keith Holman <keith.holman@windriver.com>