### PR TITLE
Transaction support + MQTT connection stabilzation

### DIFF
--- a/src/api/iot_base.c
+++ b/src/api/iot_base.c
@@ -1123,7 +1123,10 @@ iot_status_t iot_loop_forever( iot_t *lib )
 		result = IOT_STATUS_SUCCESS;
 		while( result == IOT_STATUS_SUCCESS &&
 			lib->to_quit == IOT_FALSE )
-			result = iot_loop_iteration( lib, 1000u );
+		{
+			result = iot_loop_iteration( lib,
+				IOT_MILLISECONDS_IN_SECOND );
+		}
 	}
 	return result;
 }
@@ -1147,6 +1150,11 @@ iot_status_t iot_loop_iteration( iot_t *lib, iot_millisecond_t max_time_out )
 			 * main thread */
 			result = iot_action_process( lib, max_time_out );
 		}
+
+#ifdef IOT_THREAD_SUPPORT
+		/* this prevents 100% CPU utilization */
+		os_time_sleep( max_time_out, IOT_TRUE );
+#endif
 	}
 	return result;
 }

--- a/src/api/iot_base.c
+++ b/src/api/iot_base.c
@@ -539,7 +539,7 @@ iot_status_t iot_base_device_id_set(
 				IOT_DEFAULT_FILE_DEVICE_ID );
 
 			fd = os_file_open( file_path, OS_READ );
-			*device_id = '\0';
+			os_memzero( device_id, IOT_ID_MAX_LEN + 1u );
 			if ( fd  != OS_FILE_INVALID )
 			{
 				/* read uuid from the file */
@@ -549,6 +549,9 @@ iot_status_t iot_base_device_id_set(
 				os_file_close( fd );
 				if( device_id_len >= IOT_ID_MAX_LEN )
 					device_id_len = IOT_ID_MAX_LEN;
+				if ( device_id_len > 0u &&
+					device_id[device_id_len] == '\n' )
+					--device_id_len;
 				device_id[device_id_len] = '\0';
 				if ( device_id_len > 0u )
 					IOT_LOG( NULL, IOT_LOG_INFO,
@@ -1340,15 +1343,18 @@ iot_timestamp_t iot_timestamp_now( void )
 	return time_stamp;
 }
 
-iot_bool_t iot_transaction_status(
+iot_status_t iot_transaction_status(
+	iot_t *lib,
 	const iot_transaction_t *txn,
-	iot_millisecond_t UNUSED(max_time_out) )
+	iot_millisecond_t max_time_out )
 {
-	iot_bool_t result = IOT_FALSE;
-	if ( txn )
+	iot_status_t result = IOT_STATUS_BAD_PARAMETER;
+	if ( lib && txn )
 	{
-		if ( txn->status == IOT_STATUS_SUCCESS )
-			result = IOT_TRUE;
+		result = iot_plugin_perform( lib,
+			NULL, &max_time_out,
+			IOT_OPERATION_TRANSACTION_STATUS,
+			txn, NULL, NULL );
 	}
 	return result;
 }

--- a/src/api/iot_mqtt.c
+++ b/src/api/iot_mqtt.c
@@ -443,6 +443,31 @@ iot_status_t iot_mqtt_connect_impl(
 				opts->ssl_conf->insecure );
 		}
 
+		switch ( opts->version )
+		{
+			case IOT_MQTT_VERSION_3_1:
+			{
+				int ver = MQTT_PROTOCOL_V31;
+				mosquitto_opts_set(
+					mqtt->mosq,
+					MOSQ_OPT_PROTOCOL_VERSION,
+					&ver );
+				break;
+			}
+			case IOT_MQTT_VERSION_3_1_1:
+			{
+				int ver = MQTT_PROTOCOL_V31;
+				mosquitto_opts_set(
+					mqtt->mosq,
+					MOSQ_OPT_PROTOCOL_VERSION,
+					&ver );
+				break;
+			}
+			case IOT_MQTT_VERSION_DEFAULT:
+			default:
+				break;
+		}
+
 #ifdef IOT_THREAD_SUPPORT
 		if ( reconnect == IOT_FALSE )
 			mosq_res = mosquitto_connect_async( mqtt->mosq,
@@ -519,8 +544,24 @@ iot_status_t iot_mqtt_connect_impl(
 			iot_mqtt_on_delivery );
 		conn_opts.keepAliveInterval = IOT_MQTT_KEEP_ALIVE;
 		conn_opts.cleansession = !reconnect;
-		conn_opts.username = opts->username;
-		conn_opts.password = opts->password;
+		if ( opts->version != IOT_MQTT_VERSION_3_1 )
+		{
+			conn_opts.username = opts->username;
+			conn_opts.password = opts->password;
+		}
+
+		switch ( opts->version )
+		{
+			case IOT_MQTT_VERSION_3_1:
+				conn_opts.MQTTVersion = MQTTVERSION_3_1;
+				break;
+			case IOT_MQTT_VERSION_3_1_1:
+				conn_opts.MQTTVersion = MQTTVERSION_3_1_1;
+				break;
+			case IOT_MQTT_VERSION_DEFAULT:
+			default:
+				break;
+		}
 
 #ifdef IOT_THREAD_SUPPORT
 		conn_opts.onSuccess = iot_mqtt_on_success;

--- a/src/api/iot_mqtt.c
+++ b/src/api/iot_mqtt.c
@@ -214,8 +214,30 @@ static IOT_SECTION int iot_mqtt_on_message(
 	char *topic,
 	int topic_len,
 	PAHO_OBJ( _message ) *message );
-
 #endif /* else ifdef IOT_MQTT_MOSQUITTO */
+
+/**
+ * @brief implementation for connecting to an MQTT broker
+ *
+ * @param[in,out]  mqtt                MQTT object structure to connect with
+ * @param[in]      opts                connection options
+ * @param[in]      max_time_out        maximum time to wait
+ *                                     (0 = wait indefinitely)
+ * @param[in]      reconnect           whether this is a reconnection or an
+ *                                     original connection
+ *
+ * @retval IOT_STATUS_BAD_PARAMETER    invalid parameter passed to the function
+ * @retval IOT_STATUS_FAILURE          operation failed
+ * @retval IOT_STATUS_SUCCESS          operation successful
+ *
+ * @see iot_mqtt_connect
+ * @see iot_mqtt_reconnect
+ */
+static IOT_SECTION iot_status_t iot_mqtt_connect_impl(
+	iot_mqtt_t *mqtt,
+	const iot_mqtt_connect_options_t *opts,
+	iot_millisecond_t max_time_out,
+	iot_bool_t reconnect );
 
 /** @brief number of seconds before sending a keep alive message */
 #define IOT_MQTT_KEEP_ALIVE            60u
@@ -227,70 +249,60 @@ struct iot_mqtt
 {
 #ifdef IOT_THREAD_SUPPORT
 	/** @brief Mutex to protect signal condition variable */
-	os_thread_mutex_t           notification_mutex;
+	os_thread_mutex_t                notification_mutex;
 	/** @brief Signal for waking another thread waiting for notification */
-	os_thread_condition_t       notification_signal;
+	os_thread_condition_t            notification_signal;
 #endif /* ifdef IOT_THREAD_SUPPORT */
 
 #ifdef IOT_MQTT_MOSQUITTO
 	/** @brief pointer to the mosquitto client instance */
-	struct mosquitto *mosq;
+	struct mosquitto                 *mosq;
 #else /* ifdef IOT_MQTT_MOSQUITTO */
 #ifdef IOT_THREAD_SUPPORT
 	/** @brief paho asynchronous client instance */
-	MQTTAsync client;
+	MQTTAsync                        client;
 	/** @brief Current message identifier, increments each message */
-	MQTTAsync_token msg_id;
+	MQTTAsync_token                  msg_id;
 #else /* ifdef IOT_THREAD_SUPPORT */
 	/** @brief paho synchronous client instance */
-	MQTTClient client;
+	MQTTClient                       client;
 #endif /* else ifdef IOT_THREAD_SUPPORT */
 #endif /* else ifdef IOT_MQTT_MOSQUITTO */
 	/** @brief whether the client is expected to be connected */
-	iot_bool_t connected;
+	iot_bool_t                       is_connected;
 	/** @brief whether the client cloud connection is changed */
-	iot_bool_t connection_changed;
+	iot_bool_t                       connection_changed;
 	/** @brief timestamp when the client cloud connection is changed */
-	iot_timestamp_t time_stamp_connection_changed;
+	iot_timestamp_t                  time_stamp_changed;
 	/** @brief the client cloud reconnect counter */
-	iot_uint32_t reconnect_count;
+	iot_uint32_t                     reconnect_count;
 	/** @brief callback to call when a disconnection is detected */
-	iot_mqtt_disconnect_callback_t on_disconnect;
+	iot_mqtt_disconnect_callback_t   on_disconnect;
 	/** @brief callback to call when a message is delivered */
-	iot_mqtt_delivery_callback_t   on_delivery;
+	iot_mqtt_delivery_callback_t     on_delivery;
 	/** @brief callback to call when a message is received */
-	iot_mqtt_message_callback_t on_message;
+	iot_mqtt_message_callback_t      on_message;
 	/** @brief user specified data to pass to callbacks */
 	void * user_data;
 };
 
 iot_mqtt_t* iot_mqtt_connect(
-	const char *client_id,
-	const char *host,
-	iot_uint16_t port,
-	iot_mqtt_ssl_t *ssl_conf,
-	iot_mqtt_proxy_t *proxy_conf,
-	const char *username,
-	const char *password,
+	const iot_mqtt_connect_options_t *opts,
 	iot_millisecond_t max_time_out )
 {
 	iot_mqtt_t *result = NULL;
-	if ( host && client_id )
+	if ( opts && opts->host && opts->client_id )
 	{
-		if ( port == 0u )
-		{
-			if ( ssl_conf )
-				port = IOT_MQTT_PORT_SSL;
-			else
-				port = IOT_MQTT_PORT;
-		}
-
 		result = (iot_mqtt_t*)os_malloc( sizeof( struct iot_mqtt ) );
 		if ( result )
 		{
+			iot_status_t connect_result = IOT_STATUS_FAILURE;
 #ifndef IOT_MQTT_MOSQUITTO
+			iot_uint16_t port = opts->port;
 			char url[IOT_MQTT_URL_MAX + 1u];
 #endif /* ifndef IOT_MQTT_MOSQUITTO */
+
+			os_memzero( result, sizeof( struct iot_mqtt ) );
 
 #ifdef IOT_THREAD_SUPPORT
 			os_thread_mutex_create(
@@ -299,199 +311,264 @@ iot_mqtt_t* iot_mqtt_connect(
 				&result->notification_signal );
 #endif /* ifdef IOT_THREAD_SUPPORT */
 
-			os_memzero( result, sizeof( struct iot_mqtt ) );
-
 #ifdef IOT_MQTT_MOSQUITTO
-			result->mosq = mosquitto_new( client_id, true, result );
-			result->connected = IOT_FALSE;
+			result->mosq = mosquitto_new( opts->client_id, true,
+				result );
 			if ( result->mosq )
 			{
-				mosquitto_connect_callback_set( result->mosq,
-					iot_mqtt_on_connect );
-				mosquitto_disconnect_callback_set( result->mosq,
-					iot_mqtt_on_disconnect );
-				mosquitto_message_callback_set( result->mosq,
-					iot_mqtt_on_message );
-				mosquitto_publish_callback_set( result->mosq,
-					iot_mqtt_on_delivery );
-				mosquitto_subscribe_callback_set( result->mosq,
-					iot_mqtt_on_subscribe );
-				mosquitto_log_callback_set( result->mosq,
-					iot_mqtt_on_log );
-				if ( username && password )
-					mosquitto_username_pw_set( result->mosq,
-						username, password );
-
-				if ( proxy_conf )
-				{
-					if ( proxy_conf->type == IOT_PROXY_SOCKS5 )
-						mosquitto_socks5_set(
-							result->mosq,
-							proxy_conf->host,
-							(int)proxy_conf->port,
-							proxy_conf->username,
-							proxy_conf->password );
-					else
-						os_fprintf(OS_STDERR,
-							"unsuppored proxy setting: "
-							"host port %d proxy_type %d !\n",
-							(int)port,
-							(int)proxy_conf->type );
-				}
-
-				if ( ssl_conf && port != 1883u )
-				{
-					mosquitto_tls_set( result->mosq,
-						ssl_conf->ca_path, NULL,
-						ssl_conf->cert_file,
-						ssl_conf->key_file, NULL );
-					mosquitto_tls_insecure_set(
-						result->mosq,
-						ssl_conf->insecure );
-				}
-
-				if ( mosquitto_connect( result->mosq,
-					host, port, IOT_MQTT_KEEP_ALIVE ) == MOSQ_ERR_SUCCESS )
-				{
-#ifdef IOT_THREAD_SUPPORT
-					mosquitto_loop_start( result->mosq );
-
-					/* wait here until connected or timed out! */
-					if ( max_time_out > 0u )
-						os_thread_condition_timed_wait(
-							&result->notification_signal,
-							&result->notification_mutex,
-							max_time_out );
-					else
-						os_thread_condition_wait(
-							&result->notification_signal,
-							&result->notification_mutex );
-#else /* ifdef IOT_THREAD_SUPPORT */
-					int rs = MOSQ_ERR_SUCCESS;
-					os_timestamp_t ts = 0u;
-					/* default is to wait for 1 day */
-					iot_millisecond_t wait_time = 1000u * 86400u;
-
-					if ( max_time_out > 0u )
-						wait_time = max_time_out;
-
-					/* loop until connected or time out */
-					os_time( &ts, NULL );
-					while ( rs == MOSQ_ERR_SUCCESS &&
-						result->connected == IOT_FALSE &&
-						wait_time > 0u )
-					{
-						rs = mosquitto_loop(
-							result->mosq,
-							wait_time, 1 );
-
-						if ( max_time_out > 0u )
-							os_time_remaining( &ts,
-								max_time_out,
-								&wait_time );
-					}
-#endif /* ifdef IOT_THREAD_SUPPORT */
-				}
-			}
 #else /* ifdef IOT_MQTT_MOSQUITTO */
-			if ( ssl_conf && port != 1883u )
+			if ( port == 0u )
+			{
+				if ( opts->ssl_conf )
+					port = IOT_MQTT_PORT_SSL;
+				else
+					port = IOT_MQTT_PORT;
+			}
+
+			if ( opts->ssl_conf && port != IOT_MQTT_PORT )
 				os_snprintf( url, IOT_MQTT_URL_MAX,
-					"ssl://%s:%d", host, port );
+					"ssl://%s:%d", opts->host, port );
 			else
 				os_snprintf( url, IOT_MQTT_URL_MAX,
-					"tcp://%s:%d", host, port );
+					"tcp://%s:%d", opts->host, port );
 			url[ IOT_MQTT_URL_MAX ] = '\0';
 
-			if ( proxy_conf )
-				os_fprintf(OS_STDERR,
-					"unsuppored proxy setting: "
-					"host port %d proxy_type %d !\n",
-					(int)port,
-					(int)proxy_conf->type );
-
-			result->connected = IOT_FALSE;
 			if ( PAHO_OBJ( _create )( &result->client, url,
-				client_id, MQTTCLIENT_PERSISTENCE_NONE,
+				opts->client_id, MQTTCLIENT_PERSISTENCE_NONE,
 				NULL ) == PAHO_RES( _SUCCESS ) )
 			{
-				PAHO_OBJ( _connectOptions ) conn_opts =
-					PAHO_OBJ( _connectOptions_initializer );
+#endif /* else ifdef IOT_MQTT_MOSQUITTO */
 
-				/* ssl */
-				PAHO_OBJ( _SSLOptions ) ssl_opts =
-					PAHO_OBJ( _SSLOptions_initializer );
-
-				/* this uses PAHO in asynchronous mode, this
-				 * mode is only safe in single-thread mode */
-				PAHO_OBJ( _setCallbacks )( result->client,
-					result,
-					iot_mqtt_on_disconnect,
-					iot_mqtt_on_message,
-					iot_mqtt_on_delivery );
-				conn_opts.keepAliveInterval = IOT_MQTT_KEEP_ALIVE;
-				conn_opts.cleansession = 1;
-				conn_opts.username = username;
-				conn_opts.password = password;
-#ifdef IOT_THREAD_SUPPORT
- 				conn_opts.onSuccess = iot_mqtt_on_success;
-				conn_opts.onFailure = iot_mqtt_on_failure;
-				conn_opts.context = result;
-#endif /* ifdef IOT_THREAD_SUPPORT */
-
-				if ( ssl_conf && port != 1883u )
-				{ /* ssl */
-					/* ssl args */
-					ssl_opts.trustStore = ssl_conf->ca_path;
-					ssl_opts.enableServerCertAuth =
-						!ssl_conf->insecure;
-
-					/* client cert and key */
-					ssl_opts.keyStore = ssl_conf->cert_file;
-					ssl_opts.privateKey = ssl_conf->key_file;
-
-					conn_opts.ssl = &ssl_opts;
-				}
-				if ( max_time_out > 0u )
-					conn_opts.connectTimeout =
-						(max_time_out /
-						IOT_MILLISECONDS_IN_SECOND) + 1u;
-
-				if ( PAHO_OBJ( _connect )( result->client,
-						&conn_opts ) == PAHO_RES( _SUCCESS ) )
-				{
-#ifdef IOT_THREAD_SUPPORT
-					/* wait here until connected or timed out! */
-					if ( max_time_out > 0u )
-						os_thread_condition_timed_wait(
-							&result->notification_signal,
-							&result->notification_mutex,
-							max_time_out );
-					else
-						os_thread_condition_wait(
-							&result->notification_signal,
-							&result->notification_mutex );
-#else /* ifdef IOT_THREAD_SUPPORT */
-					result->connected = IOT_TRUE;
-#endif /* else ifdef IOT_THREAD_SUPPORT */
-				}
-
-				/* failed to connect, so let's clean up */
-				if ( result && result->connected == IOT_FALSE )
-					PAHO_OBJ( _destroy )( &result->client );
+				/* try to connect */
+				connect_result = iot_mqtt_connect_impl(
+					result, opts, max_time_out, IOT_FALSE );
 			}
-#endif /* else IOT_MQTT_MOSQUITTO */
-			if ( result && result->connected == IOT_FALSE )
+
+			/* failed to connect, so let's clean up */
+			if ( connect_result != IOT_STATUS_SUCCESS )
 			{
+#ifdef IOT_MQTT_MOSQUITTO
+				if ( result->mosq )
+					mosquitto_destroy( result->mosq );
+#else /* ifdef IOT_MQTT_MOSQUITTO */
+				PAHO_OBJ( _destroy )( &result->client );
+#endif /* else ifdef IOT_MQTT_MOSQUITTO */
+
 #ifdef IOT_THREAD_SUPPORT
 				os_thread_condition_destroy(
 					&result->notification_signal );
 				os_thread_mutex_destroy(
 					&result->notification_mutex );
 #endif /* ifdef IOT_THREAD_SUPPORT */
+
 				os_free( result );
 				result = NULL;
 			}
 		}
+	}
+	return result;
+}
+
+iot_status_t iot_mqtt_connect_impl(
+	iot_mqtt_t *mqtt,
+	const iot_mqtt_connect_options_t *opts,
+	iot_millisecond_t max_time_out,
+	iot_bool_t reconnect )
+{
+	iot_status_t result = IOT_STATUS_BAD_PARAMETER;
+	if ( mqtt && opts && opts->host && opts->client_id )
+	{
+#ifdef IOT_MQTT_MOSQUITTO
+		int mosq_res;
+#else /* ifdef IOT_MQTT_MOSQUITTO */
+		PAHO_OBJ( _connectOptions ) conn_opts =
+			PAHO_OBJ( _connectOptions_initializer );
+		PAHO_OBJ( _SSLOptions ) ssl_opts =
+			PAHO_OBJ( _SSLOptions_initializer );
+#endif /* else ifdef IOT_MQTT_MOSQUITTO */
+		iot_uint16_t port = opts->port;
+		mqtt->is_connected = IOT_FALSE;
+
+		result = IOT_STATUS_FAILURE;
+		if ( port == 0u )
+		{
+			if ( opts->ssl_conf )
+				port = IOT_MQTT_PORT_SSL;
+			else
+				port = IOT_MQTT_PORT;
+		}
+
+#ifdef IOT_MQTT_MOSQUITTO
+		mosquitto_connect_callback_set( mqtt->mosq,
+			iot_mqtt_on_connect );
+		mosquitto_disconnect_callback_set( mqtt->mosq,
+			iot_mqtt_on_disconnect );
+		mosquitto_message_callback_set( mqtt->mosq,
+			iot_mqtt_on_message );
+		mosquitto_publish_callback_set( mqtt->mosq,
+			iot_mqtt_on_delivery );
+		mosquitto_subscribe_callback_set( mqtt->mosq,
+			iot_mqtt_on_subscribe );
+		mosquitto_log_callback_set( mqtt->mosq,
+			iot_mqtt_on_log );
+		if ( opts->username && opts->password )
+			mosquitto_username_pw_set( mqtt->mosq,
+				opts->username, opts->password );
+
+		if ( opts->proxy_conf )
+		{
+			if ( opts->proxy_conf->type == IOT_PROXY_SOCKS5 )
+				mosquitto_socks5_set(
+					mqtt->mosq,
+					opts->proxy_conf->host,
+					(int)opts->proxy_conf->port,
+					opts->proxy_conf->username,
+					opts->proxy_conf->password );
+			else
+				os_fprintf(OS_STDERR,
+					"unsuppored proxy setting: "
+					"host port %d proxy_type %d !\n",
+					(int)opts->proxy_conf->port,
+					(int)opts->proxy_conf->type );
+		}
+
+		if ( opts->ssl_conf && port != IOT_MQTT_PORT )
+		{
+			mosquitto_tls_set( mqtt->mosq,
+				opts->ssl_conf->ca_path, NULL,
+				opts->ssl_conf->cert_file,
+				opts->ssl_conf->key_file, NULL );
+			mosquitto_tls_insecure_set(
+				mqtt->mosq,
+				opts->ssl_conf->insecure );
+		}
+
+#ifdef IOT_THREAD_SUPPORT
+		if ( reconnect == IOT_FALSE )
+			mosq_res = mosquitto_connect_async( mqtt->mosq,
+				opts->host, opts->port, IOT_MQTT_KEEP_ALIVE );
+		else
+			mosq_res = mosquitto_reconnect_async( mqtt->mosq );
+
+		if ( mosq_res == MOSQ_ERR_SUCCESS )
+		{
+			mosquitto_loop_start( mqtt->mosq );
+
+			/* wait here until connected or timed out! */
+			if ( max_time_out > 0u )
+				os_thread_condition_timed_wait(
+					&mqtt->notification_signal,
+					&mqtt->notification_mutex,
+					max_time_out );
+			else
+				os_thread_condition_wait(
+					&mqtt->notification_signal,
+					&mqtt->notification_mutex );
+		}
+#else /* ifdef IOT_THREAD_SUPPORT */
+		if ( reconnect == IOT_FALSE )
+			mosq_res = mosquitto_connect( mqtt->mosq,
+				opts->host, opts->port, IOT_MQTT_KEEP_ALIVE );
+		else
+			mosq_res = mosquitto_reconnect( mqtt->mosq );
+
+		if ( mosq_res == MOSQ_ERR_SUCCESS )
+		{
+			os_timestamp_t ts = 0u;
+
+			/* default is to wait for 1 day */
+			iot_millisecond_t wait_time =
+				IOT_MILLISECONDS_IN_SECOND *
+				IOT_SECONDS_IN_MINUTE *
+				IOT_MINUTES_IN_HOUR * IOT_HOURS_IN_DAY;
+
+			if ( max_time_out > 0u )
+				wait_time = max_time_out;
+
+			/* loop until connected or time out */
+			os_time( &ts, NULL );
+			while ( mosq_res == MOSQ_ERR_SUCCESS &&
+				mqtt->is_connected == IOT_FALSE &&
+				wait_time > 0u )
+			{
+				mosq_res = mosquitto_loop(
+					mqtt->mosq,
+					wait_time, 1 );
+
+				if ( max_time_out > 0u )
+					os_time_remaining( &ts,
+						max_time_out,
+						&wait_time );
+			}
+		}
+#endif /* ifdef IOT_THREAD_SUPPORT */
+#else /* ifdef IOT_MQTT_MOSQUITTO */
+		if ( opts->proxy_conf )
+			os_fprintf(OS_STDERR,
+				"unsuppored proxy setting: "
+				"host port %d proxy_type %d !\n",
+				(int)opts->proxy_conf->port,
+				(int)opts->proxy_conf->type );
+
+		/* this uses PAHO in asynchronous mode, this
+		 * mode is only safe in single-thread mode */
+		PAHO_OBJ( _setCallbacks )( mqtt->client,
+			mqtt,
+			iot_mqtt_on_disconnect,
+			iot_mqtt_on_message,
+			iot_mqtt_on_delivery );
+		conn_opts.keepAliveInterval = IOT_MQTT_KEEP_ALIVE;
+		conn_opts.cleansession = !reconnect;
+		conn_opts.username = opts->username;
+		conn_opts.password = opts->password;
+
+#ifdef IOT_THREAD_SUPPORT
+		conn_opts.onSuccess = iot_mqtt_on_success;
+		conn_opts.onFailure = iot_mqtt_on_failure;
+		conn_opts.context = mqtt;
+#endif /* ifdef IOT_THREAD_SUPPORT */
+
+		if ( opts->ssl_conf && port != IOT_MQTT_PORT )
+		{ /* ssl */
+			/* ssl args */
+			ssl_opts.trustStore = opts->ssl_conf->ca_path;
+			ssl_opts.enableServerCertAuth =
+				!opts->ssl_conf->insecure;
+
+			/* client cert and key */
+			ssl_opts.keyStore = opts->ssl_conf->cert_file;
+			ssl_opts.privateKey = opts->ssl_conf->key_file;
+
+			conn_opts.ssl = &ssl_opts;
+		}
+
+		if ( max_time_out > 0u )
+			conn_opts.connectTimeout =
+				(max_time_out /
+				IOT_MILLISECONDS_IN_SECOND) + 1u;
+
+		if ( PAHO_OBJ( _connect )( mqtt->client,
+				&conn_opts ) == PAHO_RES( _SUCCESS ) )
+		{
+#ifdef IOT_THREAD_SUPPORT
+			/* wait here until connected or timed out! */
+			if ( max_time_out > 0u )
+				os_thread_condition_timed_wait(
+					&mqtt->notification_signal,
+					&mqtt->notification_mutex,
+					max_time_out );
+			else
+				os_thread_condition_wait(
+					&mqtt->notification_signal,
+					&mqtt->notification_mutex );
+#else /* ifdef IOT_THREAD_SUPPORT */
+			mqtt->is_connected = IOT_TRUE;
+#endif /* else ifdef IOT_THREAD_SUPPORT */
+		}
+#endif /* else ifdef IOT_MQTT_MOSQUITTO */
+		/* if we connected then success */
+		if ( mqtt->is_connected != IOT_FALSE )
+			result = IOT_STATUS_SUCCESS;
 	}
 	return result;
 }
@@ -504,13 +581,15 @@ iot_status_t iot_mqtt_disconnect(
 	{
 		result = IOT_STATUS_FAILURE;
 #ifdef IOT_MQTT_MOSQUITTO
-		if ( mosquitto_disconnect( mqtt->mosq ) == MOSQ_ERR_SUCCESS )
+		if ( mqtt->is_connected != IOT_FALSE &&
+			mosquitto_disconnect( mqtt->mosq ) == MOSQ_ERR_SUCCESS )
 			result = IOT_STATUS_SUCCESS;
+#ifdef IOT_THREAD_SUPPORT
 		mosquitto_loop_stop( mqtt->mosq, true );
+#endif /* ifdef IOT_THREAD_SUPPORT */
 		mosquitto_destroy( mqtt->mosq );
 		mqtt->mosq = NULL;
 #else /* ifdef IOT_MQTT_MOSQUITTO */
-		mqtt->connected = IOT_FALSE;
 #ifdef IOT_THREAD_SUPPORT
 		{
 			MQTTAsync_disconnectOptions opts =
@@ -521,8 +600,6 @@ iot_status_t iot_mqtt_disconnect(
 				result = IOT_STATUS_SUCCESS;
 			MQTTAsync_destroy( &mqtt->client );
 		}
-		os_thread_condition_destroy( &mqtt->notification_signal );
-		os_thread_mutex_destroy( &mqtt->notification_mutex );
 #else /* ifdef IOT_THREAD_SUPPORT */
 		if ( MQTTClient_disconnect( mqtt->client, IOT_MQTT_KEEP_ALIVE )
 			== MQTTCLIENT_SUCCESS )
@@ -530,6 +607,13 @@ iot_status_t iot_mqtt_disconnect(
 		MQTTClient_destroy( &mqtt->client );
 #endif /* else ifdef IOT_THREAD_SUPPORT */
 #endif /* else ifdef IOT_MQTT_MOSQUITTO */
+
+#ifdef IOT_THREAD_SUPPORT
+		os_thread_condition_destroy( &mqtt->notification_signal );
+		os_thread_mutex_destroy( &mqtt->notification_mutex );
+#endif /* ifdef IOT_THREAD_SUPPORT */
+
+		mqtt->is_connected = IOT_FALSE;
 		os_free( mqtt );
 	}
 	return result;
@@ -545,12 +629,12 @@ IOT_API IOT_SECTION iot_status_t iot_mqtt_get_connection_status(
 	if ( mqtt )
 	{
 		if( connected )
-			*connected = mqtt->connected;
+			*connected = mqtt->is_connected;
 		if( connection_changed )
 			*connection_changed = mqtt->connection_changed;
 		if ( time_stamp_connection_changed )
 			*time_stamp_connection_changed =
-				mqtt->time_stamp_connection_changed;
+				mqtt->time_stamp_changed;
 		result = IOT_STATUS_SUCCESS;
 	}
 	return result;
@@ -598,11 +682,11 @@ void iot_mqtt_on_connect(
 	int UNUSED(rc) )
 {
 	iot_mqtt_t *const mqtt = (iot_mqtt_t *)user_data;
-	if ( mqtt && mqtt->connected == IOT_FALSE )
+	if ( mqtt && mqtt->is_connected == IOT_FALSE )
 	{
-		mqtt->connected = IOT_TRUE;
+		mqtt->is_connected = IOT_TRUE;
 		mqtt->connection_changed = IOT_TRUE;
-		mqtt->time_stamp_connection_changed = iot_timestamp_now();
+		mqtt->time_stamp_changed = iot_timestamp_now();
 
 #ifdef IOT_THREAD_SUPPORT
 		/* notify iot_mqtt_connect, that we've estalished a connection */
@@ -621,9 +705,9 @@ void iot_mqtt_on_disconnect(
 	if ( mqtt )
 	{
 		const iot_bool_t unexpected = rc ? IOT_TRUE : IOT_FALSE;
-		mqtt->connected = IOT_FALSE;
+		mqtt->is_connected = IOT_FALSE;
 		mqtt->connection_changed = IOT_TRUE;
-		mqtt->time_stamp_connection_changed = iot_timestamp_now();
+		mqtt->time_stamp_changed = iot_timestamp_now();
 		mqtt->reconnect_count = 0u;
 		if ( mqtt->on_disconnect )
 			mqtt->on_disconnect( mqtt->user_data, unexpected );
@@ -677,10 +761,11 @@ void iot_mqtt_on_disconnect(
 	iot_mqtt_t *const mqtt = (iot_mqtt_t *)user_data;
 	if ( mqtt )
 	{
-		const iot_bool_t unexpected = mqtt->connected;
-		mqtt->connected = IOT_FALSE;
+		/* this function is called after a keep-alive timeout fails */
+		const iot_bool_t unexpected = mqtt->is_connected;
+		mqtt->is_connected = IOT_FALSE;
 		mqtt->connection_changed = IOT_TRUE;
-		mqtt->time_stamp_connection_changed = iot_timestamp_now();
+		mqtt->time_stamp_changed = iot_timestamp_now();
 		mqtt->reconnect_count = 0u;
 		if( mqtt->on_disconnect )
 			mqtt->on_disconnect( mqtt->user_data, unexpected );
@@ -709,7 +794,11 @@ void iot_mqtt_on_failure(
 	iot_mqtt_t *const mqtt = (iot_mqtt_t *)user_data;
 	if ( mqtt && response && response->token == 0u )
 	{
-		mqtt->connected = IOT_FALSE;
+		if ( mqtt->is_connected != IOT_FALSE )
+		{
+			mqtt->is_connected = IOT_FALSE;
+			mqtt->time_stamp_changed = iot_timestamp_now();
+		}
 		os_thread_condition_signal( &mqtt->notification_signal,
 			&mqtt->notification_mutex );
 	}
@@ -741,7 +830,12 @@ void iot_mqtt_on_success(
 	iot_mqtt_t *const mqtt = (iot_mqtt_t *)user_data;
 	if ( mqtt && response && response->token == 0u )
 	{
-		mqtt->connected = IOT_TRUE;
+		/* called on a connection */
+		if ( mqtt->is_connected == IOT_FALSE )
+		{
+			mqtt->is_connected = IOT_TRUE;
+			mqtt->time_stamp_changed = iot_timestamp_now();
+		}
 		os_thread_condition_signal( &mqtt->notification_signal,
 			&mqtt->notification_mutex );
 	}
@@ -812,109 +906,19 @@ iot_status_t iot_mqtt_publish(
 
 iot_status_t iot_mqtt_reconnect(
 	iot_mqtt_t *mqtt,
-	const char *client_id,
-	const char *host,
-	iot_uint16_t port,
-	iot_mqtt_ssl_t *ssl_conf,
-	const char *username,
-	const char *password,
+	const iot_mqtt_connect_options_t *opts,
 	iot_millisecond_t max_time_out )
 {
 	iot_status_t result = IOT_STATUS_BAD_PARAMETER;
 #ifdef IOT_MQTT_MOSQUITTO
-	(void)username;
-	(void)password;
 	(void)max_time_out;
-	if ( host && client_id && mqtt )
+	if ( opts && opts->host && opts->client_id && mqtt )
 #else /* ifdef IOT_MQTT_MOSQUITTO */
-	if ( host && client_id && mqtt && mqtt->client)
+	if ( opts && opts->host && opts->client_id && mqtt && mqtt->client)
 #endif /* else ifdef IOT_MQTT_MOSQUITTO */
 	{
-		result = IOT_STATUS_FAILURE;
-		if ( port == 0u )
-		{
-			if ( ssl_conf )
-				port = IOT_MQTT_PORT_SSL;
-			else
-				port = IOT_MQTT_PORT;
-		}
-
-#ifdef IOT_MQTT_MOSQUITTO
-		if ( mqtt->connection_changed == IOT_TRUE &&
-		     mqtt->connected == IOT_TRUE )
-		{
-			mqtt->connection_changed = IOT_FALSE;
-			result = IOT_STATUS_SUCCESS;
-		}
-#else /* ifdef IOT_MQTT_MOSQUITTO */
-		if ( mqtt->connected == IOT_FALSE )
-		{
-			iot_timestamp_t time_stamp_current =
-				iot_timestamp_now();
-			iot_timestamp_t time_stamp_diff =
-				time_stamp_current -
-				mqtt->time_stamp_connection_changed;
-			if ( time_stamp_diff >
-				( mqtt->reconnect_count + 0u ) *
-				IOT_MQTT_KEEP_ALIVE *
-				IOT_MILLISECONDS_IN_SECOND )
-			{ /* attempt to re-connect */
-				char url[IOT_MQTT_URL_MAX + 1u];
-				PAHO_OBJ( _connectOptions ) conn_opts =
-					PAHO_OBJ( _connectOptions_initializer );
-				/* ssl */
-				PAHO_OBJ( _SSLOptions ) ssl_opts =
-					PAHO_OBJ( _SSLOptions_initializer );
-
-				if ( ssl_conf && port != 1883u )
-					os_snprintf( url, IOT_MQTT_URL_MAX,
-						"ssl://%s:%d", host, port );
-				else
-					os_snprintf( url, IOT_MQTT_URL_MAX,
-						"tcp://%s:%d", host, port );
-				url[ IOT_MQTT_URL_MAX ] = '\0';
-
-				conn_opts.keepAliveInterval = IOT_MQTT_KEEP_ALIVE;
-				conn_opts.cleansession = 1;
-				conn_opts.username = username;
-				conn_opts.password = password;
-
-				if ( ssl_conf && port != 1883u )
-				{ /* ssl */
-					/* ssl args */
-					ssl_opts.trustStore = ssl_conf->ca_path;
-					ssl_opts.enableServerCertAuth =
-						!ssl_conf->insecure;
-
-					/* client cert and key */
-					ssl_opts.keyStore = ssl_conf->cert_file;
-					ssl_opts.privateKey = ssl_conf->key_file;
-
-					conn_opts.ssl = &ssl_opts;
-				}
-
-				if ( max_time_out > 0u )
-					conn_opts.connectTimeout =
-						(max_time_out /
-						IOT_MILLISECONDS_IN_SECOND) + 1u;
-
-				if ( PAHO_OBJ( _connect )( mqtt->client, &conn_opts )
-					== PAHO_RES( _SUCCESS ) )
-				{
-					mqtt->connected = IOT_TRUE;
-					mqtt->connection_changed = IOT_FALSE;
-					mqtt->time_stamp_connection_changed =
-						iot_timestamp_now();
-					mqtt->reconnect_count = 0u;
-					result = IOT_STATUS_SUCCESS;
-				}
-				else
-					++mqtt->reconnect_count;
-			}
-		}
-#endif /* else IOT_MQTT_MOSQUITTO */
-		if( result != IOT_STATUS_SUCCESS )
-			os_time_sleep( IOT_MILLISECONDS_IN_SECOND, OS_TRUE );
+		result = iot_mqtt_connect_impl(
+			mqtt, opts, max_time_out, IOT_TRUE );
 	}
 	return result;
 }

--- a/src/api/iot_mqtt.c
+++ b/src/api/iot_mqtt.c
@@ -896,7 +896,7 @@ iot_status_t iot_mqtt_publish(
 	if ( mqtt )
 	{
 #ifdef IOT_MQTT_MOSQUITTO
-		result = IOT_STATUS_FAILURE;
+		result = IOT_STATUS_IO_ERROR;
 		if ( mosquitto_publish( mqtt->mosq, &mid, topic, payload_len,
 			payload, qos, retain ) == MOSQ_ERR_SUCCESS )
 			result = IOT_STATUS_SUCCESS;
@@ -916,14 +916,14 @@ iot_status_t iot_mqtt_publish(
 			opts.onSuccess = iot_mqtt_on_success;
 
 			os_memcpy( pl, payload, payload_len );
-			result = IOT_STATUS_FAILURE;
+			result = IOT_STATUS_IO_ERROR;
 			rs = MQTTAsync_send( mqtt->client, topic,
 				(int)payload_len, pl, qos, retain, &opts );
 			if ( rs == MQTTASYNC_SUCCESS )
 #else /* ifdef IOT_THREAD_SUPPORT */
 			MQTTClient_deliveryToken token;
 			os_memcpy( pl, payload, payload_len );
-			result = IOT_STATUS_FAILURE;
+			result = IOT_STATUS_IO_ERROR;
 			if ( MQTTClient_publish( mqtt->client, topic,
 				(int)payload_len, pl, qos, retain, &token )
 				== MQTTCLIENT_SUCCESS )

--- a/src/api/iot_plugin.c
+++ b/src/api/iot_plugin.c
@@ -2,7 +2,7 @@
  * @file
  * @brief source file for IoT library plug-in support
  *
- * @copyright Copyright (C) 2017 Wind River Systems, Inc. All Rights Reserved.
+ * @copyright Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
  *
  * @license Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -226,7 +226,7 @@ void iot_plugin_initialize(
 
 iot_status_t iot_plugin_perform(
 	iot_t *lib,
-	iot_transaction_t *UNUSED(txn),
+	iot_transaction_t *txn,
 	iot_millisecond_t *max_time_out,
 	iot_operation_t op,
 	const void *item,
@@ -253,6 +253,13 @@ iot_status_t iot_plugin_perform(
 		if ( time_remaining == 0u )
 			ignore_time_out = IOT_TRUE;
 
+		if ( txn )
+		{
+			if ( lib->transaction_count == 0u )
+				++lib->transaction_count;
+			*txn = lib->transaction_count++;
+		}
+
 		for ( i = IOT_STEP_BEFORE; i <= IOT_STEP_AFTER
 			&& (ignore_time_out || time_remaining > 0u); ++i )
 		{
@@ -264,7 +271,7 @@ iot_status_t iot_plugin_perform(
 				{
 					iot_status_t interim_result =
 						p->execute( lib, p->data, op,
-							time_remaining, &i,
+							txn, time_remaining, &i,
 							item, value, options );
 					if ( interim_result > result )
 						result = interim_result;

--- a/src/api/plugin/tr50/tr50.c
+++ b/src/api/plugin/tr50/tr50.c
@@ -48,6 +48,8 @@
                                              IOT_MILLISECONDS_IN_SECOND /* 1 hour */
 /** @brief Amount to offset the request id by */
 #define TR50_FILE_REQUEST_ID_OFFSET          256u
+/** @brief number of seconds before sending a keep alive message */
+#define TR50_MQTT_KEEP_ALIVE                 60u
 
 #ifdef IOT_THREAD_SUPPORT
 /** @brief File transfer progress interval in seconds */
@@ -1067,6 +1069,7 @@ iot_status_t tr50_connect(
 		con_opts.client_id = iot_id( lib );
 		con_opts.host = host;
 		con_opts.port = (iot_uint16_t)port;
+		con_opts.keep_alive = TR50_MQTT_KEEP_ALIVE;
 		con_opts.proxy_conf = proxy_conf_p;
 		con_opts.ssl_conf = &ssl_conf;
 		con_opts.username = data->thing_key;

--- a/src/api/plugin/tr50/tr50.c
+++ b/src/api/plugin/tr50/tr50.c
@@ -1071,8 +1071,8 @@ iot_status_t tr50_connect(
 		con_opts.ssl_conf = &ssl_conf;
 		con_opts.username = data->thing_key;
 		con_opts.password = app_token;
+		con_opts.version = IOT_MQTT_VERSION_3_1_1;
 		data->mqtt = iot_mqtt_connect( &con_opts, max_time_out );
-
 
 		if ( data->mqtt )
 		{
@@ -1155,6 +1155,7 @@ iot_status_t tr50_connect_check(
 			/*con_opts.proxy_conf = proxy_conf_p;*/
 			con_opts.username = data->thing_key;
 			con_opts.password = app_token;
+			con_opts.version = IOT_MQTT_VERSION_3_1_1;
 			if ( iot_mqtt_reconnect( data->mqtt, &con_opts,
 				max_time_out ) == IOT_STATUS_SUCCESS )
 			{

--- a/src/api/public/iot.h
+++ b/src/api/public/iot.h
@@ -185,7 +185,7 @@ typedef uint32_t                                 iot_severity_t;
 /** @brief Type representing a telemetry data */
 typedef struct iot_telemetry                     iot_telemetry_t;
 /** @brief Type representing communication between client and agent */
-typedef struct iot_transaction                   iot_transaction_t;
+typedef iot_uint8_t                              iot_transaction_t;
 /** @brief Type containing verison information for the library */
 typedef iot_uint32_t                             iot_version_t;
 
@@ -2230,6 +2230,7 @@ IOT_API IOT_SECTION iot_status_t iot_telemetry_publish_raw(
 #endif /* ifndef __clang__ */
 #endif /* ifndef iot_EXPORTS */
 
+/* time */
 /**
  * @brief Explicitly sets the time stamp for a piece of telemetry data
  *
@@ -2248,7 +2249,6 @@ IOT_API IOT_SECTION iot_status_t iot_telemetry_timestamp_set(
 	iot_telemetry_t *telemetry,
 	iot_timestamp_t time_stamp );
 
-/* time */
 /**
  * @brief Initializes a time stamp with the current time
  *
@@ -2259,6 +2259,27 @@ IOT_API IOT_SECTION iot_status_t iot_telemetry_timestamp_set(
  * @see iot_telemetry_timestamp_set
  */
 IOT_API IOT_SECTION iot_timestamp_t iot_timestamp_now( void );
+
+/* transaction */
+/**
+ * @brief Determine the status of a transaction
+ *
+ * @param[in]      lib                 library handle
+ * @param[in]      txn                 transaction to query
+ * @param[in]      max_time_out        maximum time to wait for query to be
+ *                                     performed
+ *
+ * @retval IOT_STATUS_BAD_PARAMETER    invalid parameter passed to the function
+ * @retval IOT_STATUS_INVOKED          message has been sent/queue no response
+ * @retval IOT_STATUS_FAILURE          failure status returned from cloud
+ * @retval IOT_STATUS_NOT_FOUND        transaction is unknown
+ * @retval IOT_STATUS_SUCCESS          success status returned from cloud
+ * @retval IOT_STATUS_TIMED_OUT        function timed out before status returned
+ */
+IOT_API IOT_SECTION iot_status_t iot_transaction_status(
+	iot_t *lib,
+	const iot_transaction_t *txn,
+	iot_millisecond_t max_time_out );
 
 /* version */
 /**

--- a/src/api/public/iot_mqtt.h
+++ b/src/api/public/iot_mqtt.h
@@ -237,7 +237,7 @@ IOT_API IOT_SECTION iot_status_t iot_mqtt_loop( iot_mqtt_t *mqtt,
  * @param[out]     msg_id              message id assigned to the message
  *
  * @retval IOT_STATUS_BAD_PARAMETER    invalid parameter passed to the function
- * @retval IOT_STATUS_FAILURE          operation failed
+ * @retval IOT_STATUS_IO_ERROR         not connected or failed to publish
  * @retval IOT_STATUS_SUCCESS          operation successful
  */
 IOT_API IOT_SECTION iot_status_t iot_mqtt_publish(

--- a/src/api/public/iot_mqtt.h
+++ b/src/api/public/iot_mqtt.h
@@ -90,6 +90,8 @@ typedef struct iot_mqtt_connect_options
 	const char *host;
 	/** @brief port to connect on (if 0, defaults: to 1883 or 8883) */
 	iot_uint16_t port;
+	/** @brief number seconds between sending MQTT pings (if 0, not set) */
+	iot_uint16_t keep_alive;
 	/** @brief proxy information (optional) */
 	iot_mqtt_proxy_t *proxy_conf;
 	/** @brief secure connection information (optional) */
@@ -116,7 +118,7 @@ typedef struct iot_mqtt_connect_options
  * @brief Initializes the @p iot_mqtt_connection_options_t structure
  */
 #define IOT_MQTT_CONNECT_OPTIONS_INIT \
-	{ NULL, NULL, 0u, NULL, NULL, NULL, NULL, IOT_MQTT_VERSION_DEFAULT }
+	{ NULL, NULL, 0u, 0u, NULL, NULL, NULL, NULL, IOT_MQTT_VERSION_DEFAULT }
 
 /**
  * @brief internal MQTT structure

--- a/src/api/public/iot_mqtt.h
+++ b/src/api/public/iot_mqtt.h
@@ -172,6 +172,27 @@ IOT_API IOT_SECTION iot_mqtt_t* iot_mqtt_connect(
 	iot_millisecond_t max_time_out );
 
 /**
+ * @brief MQTT broker connection status
+ *
+ * @param[in]      mqtt                  MQTT object to disconnect
+ * @param[out]     connected             currently connected to broker
+ * @param[out]     time_stamp_changed    time stamp when server connection last
+ *                                       changed
+ *
+ * @retval IOT_STATUS_BAD_PARAMETER      invalid parameter passed to the function
+ * @retval IOT_STATUS_FAILURE            operation failed
+ * @retval IOT_STATUS_SUCCESS            operation successful
+ *
+ * @see iot_mqtt_connect
+ * @see iot_mqtt_disconnect
+ * @see iot_mqtt_reconnect
+ */
+IOT_API IOT_SECTION iot_status_t iot_mqtt_connection_status(
+	const iot_mqtt_t* mqtt,
+	iot_bool_t *connected,
+	iot_timestamp_t *time_stamp_changed );
+
+/**
  * @brief disconnects from an MQTT server
  *
  * @param[in]      mqtt                MQTT object to disconnect
@@ -186,26 +207,6 @@ IOT_API IOT_SECTION iot_mqtt_t* iot_mqtt_connect(
 IOT_API IOT_SECTION iot_status_t iot_mqtt_disconnect(
 	iot_mqtt_t* mqtt
 	);
-
-/**
- * @brief gets MQTT server connection status
- *
- * @param[in]      mqtt                  MQTT object to disconnect
- * @param[out]     connected             server is connected
- * @param[out]     connection_changed    server connection is changed
- * @param[out]     time_stamp_connection_changed
- *                                       time stamp when server connection was
- *                                       changed
- *
- * @retval IOT_STATUS_BAD_PARAMETER      invalid parameter passed to the function
- * @retval IOT_STATUS_FAILURE            operation failed
- * @retval IOT_STATUS_SUCCESS            operation successful
- */
-IOT_API IOT_SECTION iot_status_t iot_mqtt_get_connection_status(
-	const iot_mqtt_t* mqtt,
-	iot_bool_t *connected,
-	iot_bool_t *connection_changed,
-	iot_timestamp_t *time_stamp_connection_changed );
 
 /**
  * @brief initializes MQTT functionality

--- a/src/api/public/iot_mqtt.h
+++ b/src/api/public/iot_mqtt.h
@@ -24,6 +24,19 @@ extern "C" {
 #endif /* ifdef __cplusplus */
 
 /**
+ * @brief MQTT version to use
+ */
+typedef enum iot_mqtt_version
+{
+	/** @brief Use default MQTT Version (negotiate version) */
+	IOT_MQTT_VERSION_DEFAULT = 0,
+	/** @brief Use MQTT Version 3.1 */
+	IOT_MQTT_VERSION_3_1 = 3,
+	/** @brief Use MQTT Version 3.1.1 */
+	IOT_MQTT_VERSION_3_1_1 = 4,
+} iot_mqtt_version_t;
+
+/**
  * @brief Possible types for iot proxy
  */
 typedef enum iot_proxy_type
@@ -95,13 +108,15 @@ typedef struct iot_mqtt_connect_options
 	 * MQTT version 3.1.1 protocol or higher.
 	 */
 	const char *password;
+	/** @brief MQTT protocol version to use */
+	iot_mqtt_version_t version;
 } iot_mqtt_connect_options_t;
 
 /**
  * @brief Initializes the @p iot_mqtt_connection_options_t structure
  */
 #define IOT_MQTT_CONNECT_OPTIONS_INIT \
-	{ NULL, NULL, 0u, NULL, NULL, NULL, NULL }
+	{ NULL, NULL, 0u, NULL, NULL, NULL, NULL, IOT_MQTT_VERSION_DEFAULT }
 
 /**
  * @brief internal MQTT structure

--- a/src/api/public/iot_mqtt.h
+++ b/src/api/public/iot_mqtt.h
@@ -88,7 +88,15 @@ typedef struct iot_mqtt_connect_options
 	const char *client_id;
 	/** @brief host server to connect to */
 	const char *host;
-	/** @brief port to connect on (if 0, defaults: to 1883 or 8883) */
+	/**
+	 * @brief port to connect on (optional)
+	 *
+	 * @note if set to a value of 0:
+	 * - uses @p 443 if @p websocket_path @p ssl_conf provided
+	 * - uses @p 80 if @p websocket_path provided
+	 * - uses @p 8883 if @p ssl_conf provided
+	 * - uses @p 1883 if neither @p websocket_path or @p ssl_conf not set
+	 */
 	iot_uint16_t port;
 	/** @brief number seconds between sending MQTT pings (if 0, not set) */
 	iot_uint16_t keep_alive;
@@ -112,13 +120,15 @@ typedef struct iot_mqtt_connect_options
 	const char *password;
 	/** @brief MQTT protocol version to use */
 	iot_mqtt_version_t version;
+	/** @brief HTTP to request if using websockets (optional, if NULL: don't use websockets) */
+	const char *websocket_path;
 } iot_mqtt_connect_options_t;
 
 /**
  * @brief Initializes the @p iot_mqtt_connection_options_t structure
  */
 #define IOT_MQTT_CONNECT_OPTIONS_INIT \
-	{ NULL, NULL, 0u, 0u, NULL, NULL, NULL, NULL, IOT_MQTT_VERSION_DEFAULT }
+	{ NULL, NULL, 0u, 0u, NULL, NULL, NULL, NULL, IOT_MQTT_VERSION_DEFAULT, NULL }
 
 /**
  * @brief internal MQTT structure

--- a/src/api/public/iot_mqtt.h
+++ b/src/api/public/iot_mqtt.h
@@ -67,6 +67,43 @@ typedef struct iot_mqtt_ssl
 } iot_mqtt_ssl_t;
 
 /**
+ * @brief Structure containing options for connecting to an MQTT broker
+ */
+typedef struct iot_mqtt_connect_options
+{
+	/** @brief id of the client */
+	const char *client_id;
+	/** @brief host server to connect to */
+	const char *host;
+	/** @brief port to connect on (if 0, defaults: to 1883 or 8883) */
+	iot_uint16_t port;
+	/** @brief proxy information (optional) */
+	iot_mqtt_proxy_t *proxy_conf;
+	/** @brief secure connection information (optional) */
+	iot_mqtt_ssl_t *ssl_conf;
+	/**
+	 * @brief user name to connect with (optional)
+	 *
+	 * @note This field is only applicable to clients that connect using
+	 * MQTT version 3.1.1 protocol or higher.
+	 */
+	const char *username;
+	/**
+	 * @brief password to connect with (optional)
+	 *
+	 * @note This field is only applicable to clients that connect using
+	 * MQTT version 3.1.1 protocol or higher.
+	 */
+	const char *password;
+} iot_mqtt_connect_options_t;
+
+/**
+ * @brief Initializes the @p iot_mqtt_connection_options_t structure
+ */
+#define IOT_MQTT_CONNECT_OPTIONS_INIT \
+	{ NULL, NULL, 0u, NULL, NULL, NULL, NULL }
+
+/**
  * @brief internal MQTT structure
  */
 typedef struct iot_mqtt iot_mqtt_t;
@@ -100,13 +137,10 @@ typedef void (*iot_mqtt_message_callback_t)(
 /**
  * @brief connects to an MQTT server
  *
- * @param[in]      client_id           id of the client
- * @param[in]      host                host server to connect to
- * @param[in]      port                (optional) port to connect on
- * @param[in]      ssl_conf            (optional) secure connection information
- * @param[in]      proxy_conf          (optional) proxy information
- * @param[in]      username            user name to connect with
- * @param[in]      password            password to connect with
+ * @note The @p username & @p password fields are only applicable to clients
+ * that connect using MQTT version 3.1.1 protocol or higher.
+ *
+ * @param[in]      opts                connection options
  * @param[in]      max_time_out        maximum time to wait
  *                                     (0 = wait indefinitely)
  *
@@ -114,15 +148,10 @@ typedef void (*iot_mqtt_message_callback_t)(
  * @retval         !NULL               successful connection established
  *
  * @see iot_mqtt_disconnect
+ * @see iot_mqtt_reconnect
  */
 IOT_API IOT_SECTION iot_mqtt_t* iot_mqtt_connect(
-	const char *client_id,
-	const char *host,
-	iot_uint16_t port,
-	iot_mqtt_ssl_t *ssl_conf,
-	iot_mqtt_proxy_t *proxy_conf,
-	const char *username,
-	const char *password,
+	const iot_mqtt_connect_options_t *opts,
 	iot_millisecond_t max_time_out );
 
 /**
@@ -135,6 +164,7 @@ IOT_API IOT_SECTION iot_mqtt_t* iot_mqtt_connect(
  * @retval IOT_STATUS_SUCCESS          operation successful
  *
  * @see iot_mqtt_connect
+ * @see iot_mqtt_reconnect
  */
 IOT_API IOT_SECTION iot_status_t iot_mqtt_disconnect(
 	iot_mqtt_t* mqtt
@@ -270,30 +300,23 @@ IOT_API IOT_SECTION iot_status_t iot_mqtt_set_user_data(
 	void *user_data );
 
 /**
- * @brief reconnects to an MQTT server
+ * @brief reconnects to an MQTT server after a connection
  *
- * @param[in]      mqtt                MQTT object to subscribe to
- * @param[in]      client_id           id of the client
- * @param[in]      host                host server to connect to
- * @param[in]      port                (optional) port to connect on
- * @param[in]      ssl_conf            (optional) secure connection information
- * @param[in]      username            user name to connect with
- * @param[in]      password            password to connect with
+ * @param[in,out]  mqtt                MQTT object to subscribe to
+ * @param[in]      opts                connection options
  * @param[in]      max_time_out        maximum time to wait
  *                                     (0 = wait indefinitely)
  *
  * @retval IOT_STATUS_BAD_PARAMETER    invalid parameter passed to the function
  * @retval IOT_STATUS_FAILURE          operation failed
  * @retval IOT_STATUS_SUCCESS          operation successful
+ *
+ * @see iot_mqtt_connect
+ * @see iot_mqtt_disconnect
  */
 IOT_API IOT_SECTION iot_status_t iot_mqtt_reconnect(
 	iot_mqtt_t *mqtt,
-	const char *client_id,
-	const char *host,
-	iot_uint16_t port,
-	iot_mqtt_ssl_t *ssl_conf,
-	const char *username,
-	const char *password,
+	const iot_mqtt_connect_options_t *opts,
 	iot_millisecond_t max_time_out );
 
 /**

--- a/src/api/public/iot_plugin.h
+++ b/src/api/public/iot_plugin.h
@@ -2,7 +2,7 @@
  * @file
  * @brief Header file for using the Internet of Things library
  *
- * @copyright Copyright (C) 2017 Wind River Systems, Inc. All Rights Reserved.
+ * @copyright Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
  *
  * @license Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,8 +74,11 @@ enum iot_operation
 	/** @brief ( up ) publication of a telemetry sample(s) */
 	IOT_OPERATION_TELEMETRY_PUBLISH,
 	/** @brief ( up ) telemetry registration */
-	IOT_OPERATION_TELEMETRY_REGISTER
+	IOT_OPERATION_TELEMETRY_REGISTER,
+	/** @brief ( up ) obtain the transaction status */
+	IOT_OPERATION_TRANSACTION_STATUS,
 };
+
 /** @brief current operation being performed */
 typedef enum iot_operation iot_operation_t;
 
@@ -96,6 +99,7 @@ typedef iot_status_t (*iot_plugin_execute_fptr)(
 	iot_t *lib,
 	void* plugin_data,
 	iot_operation_t op,
+	const iot_transaction_t *txn,
 	iot_millisecond_t max_time_out,
 	iot_step_t *step,
 	const void *item,

--- a/src/api/shared/iot_types.h
+++ b/src/api/shared/iot_types.h
@@ -392,15 +392,6 @@ struct iot_file_progress
 	iot_status_t status;
 };
 
-/**
- * @brief information about a transaction status for later querying
- */
-struct iot_transaction
-{
-	/** @brief indicates status */
-	iot_status_t status;
-};
-
 #if 0
 /**
  * @brief information for passing data between two (or more) clients
@@ -493,6 +484,9 @@ struct iot
 	 *       if the index is >= telemetry_count are available for use.
 	 */
 	struct iot_telemetry        *telemetry_ptr[ IOT_TELEMETRY_MAX ];
+
+	/** @brief number of the lastest transaction */
+	iot_transaction_t           transaction_count;
 
 	/** @brief about to disconnect & quit */
 	iot_bool_t                  to_quit;
@@ -1009,21 +1003,6 @@ IOT_SECTION iot_status_t iot_state_callback_set(
 	iot_state_callback_t *state_callback,
 	void *user_data );
 #endif
-
-/* transaction */
-/**
- * @brief Determine the status of a transaction
- *
- * @param[in,out]  txn                 transaction to query
- * @param[in]      max_time_out        maximum time to wait for query to be
- *                                     performed
- *
- * @retval IOT_TRUE                    entire transaction was successful
- * @retval IOT_FALSE                   transaction did not succeed
- */
-IOT_SECTION iot_bool_t iot_transaction_status(
-	const iot_transaction_t *txn,
-	iot_millisecond_t max_time_out );
 
 /* loop */
 /**

--- a/test/unit/api/iot_base_test.c
+++ b/test/unit/api/iot_base_test.c
@@ -2518,29 +2518,45 @@ static void test_iot_timestamp_now_valid( void **state )
 /* iot_transaction_status */
 static void test_iot_transaction_status_bad( void **state )
 {
-	iot_bool_t result;
-	iot_transaction_t txn;
-	bzero( &txn, sizeof( struct iot_transaction ) );
-	txn.status = IOT_STATUS_FAILURE;
-	result = iot_transaction_status( &txn, 0u );
-	assert_int_equal( result, IOT_FALSE );
+	iot_t lib;
+	iot_status_t result;
+	iot_transaction_t txn = 1u;
+
+	bzero( &lib, sizeof( struct iot ) );
+	will_return( __wrap_iot_plugin_perform, IOT_STATUS_EXECUTION_ERROR );
+	result = iot_transaction_status( &lib, &txn, 0u );
+	assert_int_equal( result, IOT_STATUS_EXECUTION_ERROR );
 }
 
 static void test_iot_transaction_status_good( void **state )
 {
-	iot_bool_t result;
-	iot_transaction_t txn;
-	bzero( &txn, sizeof( struct iot_transaction ) );
-	txn.status = IOT_STATUS_SUCCESS;
-	result = iot_transaction_status( &txn, 0u );
-	assert_int_equal( result, IOT_TRUE );
+	iot_t lib;
+	iot_status_t result;
+	iot_transaction_t txn = 2u;
+
+	bzero( &lib, sizeof( struct iot ) );
+	will_return( __wrap_iot_plugin_perform, IOT_STATUS_SUCCESS );
+	result = iot_transaction_status( &lib, &txn, 0u );
+	assert_int_equal( result, IOT_STATUS_SUCCESS );
 }
 
-static void test_iot_transaction_status_null( void **state )
+static void test_iot_transaction_status_null_lib( void **state )
 {
-	iot_bool_t result;
-	result = iot_transaction_status( NULL, 0u );
-	assert_int_equal( result, IOT_FALSE );
+	iot_status_t result;
+	iot_transaction_t txn = 3u;
+
+	result = iot_transaction_status( NULL, &txn, 0u );
+	assert_int_equal( result, IOT_STATUS_BAD_PARAMETER );
+}
+
+static void test_iot_transaction_status_null_txn( void **state )
+{
+	iot_t lib;
+	iot_status_t result;
+
+	bzero( &lib, sizeof( struct iot ) );
+	result = iot_transaction_status( &lib, NULL, 0u );
+	assert_int_equal( result, IOT_STATUS_BAD_PARAMETER );
 }
 
 /* iot_version */
@@ -2658,7 +2674,8 @@ int main( int argc, char *argv[] )
 		cmocka_unit_test( test_iot_timestamp_now_valid ),
 		cmocka_unit_test( test_iot_transaction_status_bad ),
 		cmocka_unit_test( test_iot_transaction_status_good ),
-		cmocka_unit_test( test_iot_transaction_status_null ),
+		cmocka_unit_test( test_iot_transaction_status_null_lib ),
+		cmocka_unit_test( test_iot_transaction_status_null_txn ),
 		cmocka_unit_test( test_iot_version ),
 		cmocka_unit_test( test_iot_version_str )
 	};

--- a/test/unit/mock/mock_osal.c
+++ b/test/unit/mock/mock_osal.c
@@ -115,6 +115,7 @@ os_status_t __wrap_os_thread_rwlock_write_unlock( os_thread_rwlock_t *lock );
 os_status_t __wrap_os_thread_wait( os_thread_t *thread );
 #endif /* ifdef IOT_THREAD_SUPPORT */
 os_status_t __wrap_os_time( os_timestamp_t *time_stamp, os_bool_t *up_time );
+os_status_t __wrap_os_time_sleep( os_millisecond_t ms, os_bool_t allow_interrupts );
 int __wrap_os_vfprintf( os_file_t stream, const char *format, va_list args )
 	__attribute__((format(printf,2,0)));
 int __wrap_os_vsnprintf( char *str, size_t size, const char *format, va_list args )
@@ -927,6 +928,11 @@ int __wrap_os_vsnprintf( char *str, size_t size, const char *format, va_list arg
 os_status_t __wrap_os_time( os_timestamp_t *time_stamp, os_bool_t *up_time )
 {
 	*time_stamp = 1234567u;
+	return OS_STATUS_SUCCESS;
+}
+
+os_status_t __wrap_os_time_sleep( os_millisecond_t ms, os_bool_t allow_interrupts )
+{
 	return OS_STATUS_SUCCESS;
 }
 

--- a/test/unit/mock/mock_osal.cmake
+++ b/test/unit/mock/mock_osal.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 Wind River Systems, Inc. All Rights Reserved.
+# Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -84,6 +84,7 @@ set( MOCK_OSAL_FUNC
 	"os_thread_rwlock_write_unlock"
 	"os_thread_wait"
 	"os_time"
+	"os_time_sleep"
 	"os_uuid_generate"
 	"os_uuid_to_string_lower"
 	"os_vfprintf"


### PR DESCRIPTION
This commit contains a few fixes in 2 main areas.

1)  This adds the api `iot_transaction_status` which allows the user to be able to see the status of a publish of a telemetry, attribute, or event...  when the cloud has handled that piece of information
2) This fixes connection issues that are experienced after being alive for long periods of time, but fixing the underlying mqtt sub-system.