### PR TITLE
api: show receive/send messages as debug

### DIFF
--- a/src/api/plugin/tr50/tr50.c
+++ b/src/api/plugin/tr50/tr50.c
@@ -1887,7 +1887,7 @@ iot_status_t tr50_mqtt_publish(
 	iot_status_t result = IOT_STATUS_BAD_PARAMETER;
 	if ( data && topic && payload )
 	{
-		IOT_LOG( data->lib, IOT_LOG_TRACE,
+		IOT_LOG( data->lib, IOT_LOG_DEBUG,
 			"tr50: sent (%u bytes on %s): %.*s",
 				(unsigned int)payload_len, topic,
 				(int)payload_len, (const char*)payload );
@@ -1914,7 +1914,7 @@ void tr50_on_message(
 	const iot_json_item_t *root;
 
 	if ( data )
-		IOT_LOG( data->lib, IOT_LOG_TRACE,
+		IOT_LOG( data->lib, IOT_LOG_DEBUG,
 			"tr50: received (%u bytes on %s): %.*s",
 			(unsigned int)payload_len, topic,
 			(int)payload_len, (const char *)payload );


### PR DESCRIPTION
Setting the log level to "TRACE", causes a lot of output as expected
that isn't totally helpful to non-developers.  However, setting it up a
level to "DEBUG", causes not enough information to see if there are
messages going in and out of the system.  This patch updates the code to
show raw messages that come in and out on the DEBUG level, so that there
is a good level of intermediate of information being produced.  If this
isn't desired than a user can set the level higher to "INFO".

Signed-off-by: Keith Holman <keith.holman@windriver.com>