### PR TITLE
admin_tools: remove complete app from app cfg

### DIFF
--- a/share/admin-tools/app_defs/demo_apps.cfg
+++ b/share/admin-tools/app_defs/demo_apps.cfg
@@ -38,19 +38,6 @@
         "isSuperOps":false,
         "isOrgAdmin":true,
         "license":""
-    },
-    {
-        "name":"hdc_complete_clib_app",
-        "desc":"hdc_complete_clib_app",
-        "token":"",
-        "autoRegThingDefId":"hdc_app_complete_clib_def",
-        "autoRegTags":["", ""],
-        "autoRegSecTags":["", ""],
-        "roles":"",
-        "isSuperAdmin":false,
-        "isSuperOps":false,
-        "isOrgAdmin":true,
-        "license":""
     }
     ]
 }


### PR DESCRIPTION
fixes: #100

The complete app is being removed.  The thing def does not exist
so remove the app def as well.

Signed-off-by: Paul Barrette <paulbarrette@gmail.com>