### PR TITLE
update argument parser support utility & port some unit tests from old repo

### DIFF
--- a/src/control/control_config.h
+++ b/src/control/control_config.h
@@ -2,7 +2,7 @@
  * @file
  * @brief Main source file for the Wind River IoT control configuration files
  *
- * @copyright Copyright (C) 2017 Wind River Systems, Inc. All Rights Reserved.
+ * @copyright Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
  *
  * @license Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
  * OR CONDITIONS OF ANY KIND, either express or implied."
  */
-#ifndef CONTROL_CONFIG_FILE_H
+#ifndef CONTROL_CONFIG_H
 
 #include "../api/json/iot_json_schema.h"
 
@@ -22,10 +22,12 @@
  * @brief Generates a configuration file for the product by prompting for
  *        user input
  *
+ * @param[in]      file_name           file name to generate (optional)
+ *
  * @retval IOT_STATUS_FAILURE          operating system operation failed
  * @retval IOT_STATUS_NO_MEMORY        not enough memory available
  * @retval IOT_STATUS_SUCCESS          on success
  */
-iot_status_t control_config_generate( void );
+iot_status_t control_config_generate( const char *file_name );
 
-#endif /* ifndef CONTROL_CONFIG_FILE_H */
+#endif /* ifndef CONTROL_CONFIG_H */

--- a/src/control/control_main.c
+++ b/src/control/control_main.c
@@ -2,7 +2,7 @@
  * @file
  * @brief Main source file for the Wind River IoT control application
  *
- * @copyright Copyright (C) 2017 Wind River Systems, Inc. All Rights Reserved.
+ * @copyright Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
  *
  * @license Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,14 +107,16 @@ int control_device_decommission( void )
 int control_main( int argc, char *argv[] )
 {
 	int result = EXIT_SUCCESS;
+	const char *file_name = NULL;
 
 	struct app_arg args[] = {
-		{ 'h', "help"          , 0u, NULL, NULL, "display help menu"  , 0u },
-		{ 0u , "reboot"        , 0u, NULL, NULL, "reboot the device"  , 0u },
-		{ 0u , "shutdown"      , 0u, NULL, NULL, "shutdown the device", 0u },
-		{ 'v', "version"       , 0u, NULL, NULL, "display version"    , 0u },
+		{ 'f' , "file"          , 0u, "file", &file_name, "output config file" , 0u },
+		{ 'h' , "help"          , 0u, NULL, NULL, "display help menu"  , 0u },
+		{ '\0', "reboot"        , 0u, NULL, NULL, "reboot the device"  , 0u },
+		{ '\0', "shutdown"      , 0u, NULL, NULL, "shutdown the device", 0u },
+		{ 'v' , "version"       , 0u, NULL, NULL, "display version"    , 0u },
 		{ 'd' , "decommission"  , 0u, NULL, NULL, "decommission device", 0u },
-		{ 0, NULL, 0, NULL, NULL, NULL, 0u }
+		{ '\0', NULL, 0, NULL, NULL, NULL, 0u }
 	};
 
 	result = app_arg_parse( args, argc, argv, NULL );
@@ -125,8 +127,9 @@ int control_main( int argc, char *argv[] )
 		/* Prompt user if no argument is provided
 		 * Generate iot connection configuration file
 		 */
-		if ( result == EXIT_SUCCESS && argc <= 1 )
-			control_config_generate();
+		if ( result == EXIT_SUCCESS &&
+			( argc <= 1 || app_arg_count( args, 'f', NULL ) ) )
+			control_config_generate( file_name );
 		if ( app_arg_count( args, 'v', NULL ) )
 			control_build_information();
 		if ( result == EXIT_SUCCESS &&

--- a/src/control/control_main.c
+++ b/src/control/control_main.c
@@ -110,12 +110,18 @@ int control_main( int argc, char *argv[] )
 	const char *file_name = NULL;
 
 	struct app_arg args[] = {
-		{ 'f' , "file"          , 0u, "file", &file_name, "output config file" , 0u },
-		{ 'h' , "help"          , 0u, NULL, NULL, "display help menu"  , 0u },
-		{ '\0', "reboot"        , 0u, NULL, NULL, "reboot the device"  , 0u },
-		{ '\0', "shutdown"      , 0u, NULL, NULL, "shutdown the device", 0u },
-		{ 'v' , "version"       , 0u, NULL, NULL, "display version"    , 0u },
-		{ 'd' , "decommission"  , 0u, NULL, NULL, "decommission device", 0u },
+		{ 'd' , "decommission", APP_ARG_FLAG_OPTIONAL,
+			NULL, NULL, "decommission device", 0u },
+		{ 'f' , "file", APP_ARG_FLAG_OPTIONAL,
+			"file", &file_name, "output config file", 0u },
+		{ 'h' , "help", APP_ARG_FLAG_OPTIONAL,
+			NULL, NULL, "display help menu", 0u },
+		{ '\0', "reboot", APP_ARG_FLAG_OPTIONAL,
+			NULL, NULL, "reboot the device", 0u },
+		{ '\0', "shutdown", APP_ARG_FLAG_OPTIONAL,
+			NULL, NULL, "shutdown the device", 0u },
+		{ 'v' , "version", APP_ARG_FLAG_OPTIONAL,
+			NULL, NULL, "display version", 0u },
 		{ '\0', NULL, 0, NULL, NULL, NULL, 0u }
 	};
 
@@ -135,13 +141,13 @@ int control_main( int argc, char *argv[] )
 		if ( result == EXIT_SUCCESS &&
 			app_arg_count( args, 0u, "reboot" ) )
 		{
-			result = control_device_shutdown(IOT_TRUE, IOT_REBOOT_DELAY);
+			result = control_device_shutdown( IOT_TRUE, IOT_REBOOT_DELAY );
 			os_printf("reboot device delay=%d seconds\n", IOT_REBOOT_DELAY);
 		}
 		if ( result == EXIT_SUCCESS &&
 			app_arg_count( args, 0u, "shutdown" ) )
 		{
-			result = control_device_shutdown( IOT_FALSE, IOT_REBOOT_DELAY);
+			result = control_device_shutdown( IOT_FALSE, IOT_REBOOT_DELAY );
 			os_printf("shutdown device delay=%d seconds\n", IOT_REBOOT_DELAY);
 		}
                 if ( result == EXIT_SUCCESS &&

--- a/src/device-manager/device_manager_main.c
+++ b/src/device-manager/device_manager_main.c
@@ -1243,10 +1243,12 @@ int device_manager_main( int argc, char *argv[] )
 	int result = EXIT_FAILURE;
 	const char *config_file = NULL;
 	struct app_arg args[] = {
-		{ 'c', "configure", 0, "file", &config_file,
-			"configuration file", 0u },
-		{ 'h', "help", 0, NULL, NULL, "display help menu", 0u },
-		{ 's', "service", 0, NULL, NULL, "run as a service", 0u },
+		{ 'c', "configure", APP_ARG_FLAG_OPTIONAL,
+			"file", &config_file, "configuration file", 0u },
+		{ 'h', "help", APP_ARG_FLAG_OPTIONAL,
+			NULL, NULL, "display help menu", 0u },
+		{ 's', "service", APP_ARG_FLAG_OPTIONAL,
+			NULL, NULL, "run as a service", 0u },
 		{ 0, NULL, 0, NULL, NULL, NULL, 0u }
 	};
 

--- a/src/relay/relay_main.c
+++ b/src/relay/relay_main.c
@@ -2,7 +2,7 @@
  * @file
  * @brief Main source file for the Wind River IoT relay application
  *
- * @copyright Copyright (C) 2017 Wind River Systems, Inc. All Rights Reserved.
+ * @copyright Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
  *
  * @license Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -970,22 +970,26 @@ int relay_main( int argc, char *argv[] )
 	int url_pos = 0;
 
 	struct app_arg args[] = {
-		{ 'p', "port", 1, "port", &port_str, "port to connect to", 0u },
-		{ 'b', "bind", 0, NULL, NULL,
+		{ 'p', "port", APP_ARG_FLAG_REQUIRED,
+			"port", &port_str, "port to connect to", 0u },
+		{ 'b', "bind", APP_ARG_FLAG_OPTIONAL, NULL, NULL,
 			"bind to the specified socket", 0u },
-		{ 'c', "configure", 0, "file", &config_file,
-			"configuration file", 0u },
-		{ 'h', "help", 0, NULL, NULL, "display help menu", 0u },
-		{ 'i', "insecure", 0, NULL, NULL,
+		{ 'c', "configure", APP_ARG_FLAG_OPTIONAL,
+			"file", &config_file, "configuration file", 0u },
+		{ 'h', "help", APP_ARG_FLAG_OPTIONAL, NULL, NULL,
+			"display help menu", 0u },
+		{ 'i', "insecure", APP_ARG_FLAG_OPTIONAL, NULL, NULL,
 			"disable certificate validation", 0u },
-		{ 'n', "notification", 0, "file", &notification_file,
-			"notification file", 0u },
-		{ 'o', "host", 0, "host", &host,
+		{ 'n', "notification", APP_ARG_FLAG_OPTIONAL,
+			"file", &notification_file, "notification file", 0u },
+		{ 'o', "host", APP_ARG_FLAG_OPTIONAL, "host", &host,
 			"host for socket connection", 0u },
-		{ 'u', "udp", 0, NULL, NULL, "UDP packets instead of TCP", 0u },
-		{ 'v', "verbose", 0, NULL, NULL, "verbose output", 0u },
-		{ 'f', "log-file", 0, "file", &log_file_path, 
-			"log to the file specified", 0u },
+		{ 'u', "udp", APP_ARG_FLAG_OPTIONAL, NULL, NULL,
+			"UDP packets instead of TCP", 0u },
+		{ 'v', "verbose", APP_ARG_FLAG_OPTIONAL, NULL, NULL,
+			"verbose output", 0u },
+		{ 'f', "log-file", APP_ARG_FLAG_OPTIONAL, "file",
+			&log_file_path, "log to the file specified", 0u },
 		{ 0, NULL, 0, NULL, NULL, NULL, 0u }
 	};
 

--- a/src/utilities/app_arg.h
+++ b/src/utilities/app_arg.h
@@ -21,6 +21,15 @@
 #include <stdlib.h> /* for size_t */
 #include "os.h"     /* osal functions */
 
+/** @brief Argument is required (no flags specified) */
+#define APP_ARG_FLAG_REQUIRED          0x0
+/** @brief Argument is optional */
+#define APP_ARG_FLAG_OPTIONAL          0x1
+/** @brief Argument is allowed to be specified multiple times */
+#define APP_ARG_FLAG_MULTI             0x2
+/** @brief Argument has required parameters */
+#define APP_ARG_FLAG_PARAM_OPTIONAL    0x4
+
 /** @brief Structure defining an arugment for an application */
 struct app_arg
 {
@@ -28,8 +37,8 @@ struct app_arg
 	char ch;
 	/** @brief Argument multi character token (i.e. specified with "--") */
 	const char *name;
-	/** @brief Whether the argument is required */
-	int req;
+	/** @brief Flags for this argument */
+	int flags;
 	/** @brief Parameter id used in display (optional) */
 	const char *param;
 	/** @brief Location set pointer if found (optional) */

--- a/src/utilities/app_arg.h
+++ b/src/utilities/app_arg.h
@@ -2,7 +2,7 @@
  * @file
  * @brief header file for argument parsing functionality for an application
  *
- * @copyright Copyright (C) 2016-2017 Wind River Systems, Inc. All Rights Reserved.
+ * @copyright Copyright (C) 2016-2018 Wind River Systems, Inc. All Rights Reserved.
  *
  * @license Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,15 +30,30 @@ struct app_arg
 	const char *name;
 	/** @brief Whether the argument is required */
 	int req;
-	/** @brief Parameter id used in display */
+	/** @brief Parameter id used in display (optional) */
 	const char *param;
-	/** @brief Location set pointer if found */
+	/** @brief Location set pointer if found (optional) */
 	const char **param_result;
-	/** @brief Argument description */
+	/** @brief Argument description (optional) */
 	const char *desc;
-	/** @brief Number of times argument was found */
+	/** @brief Number of times argument was found (initialize to 0)*/
 	unsigned int hit;
 };
+
+/** @brief Structure defining the iterator for going through arguments */
+struct app_arg_iterator
+{
+	/** @brief Character key iterating through */
+	char ch;
+	/** @brief Full name iterating through */
+	const char *name;
+	/** @brief Current index */
+	int idx;
+};
+/** @brief Structure of initializing an @p app_arg_iterator structure */
+#define APP_ARG_ITERATOR_INIT { '\0', NULL, 0u }
+/** @brief Type defining an argument iterator */
+typedef struct app_arg_iterator app_arg_iterator_t;
 
 /**
  * @brief Returns the number of times an argument was specified
@@ -55,6 +70,99 @@ struct app_arg
  */
 unsigned int app_arg_count( const struct app_arg *args, char ch,
 	const char *name );
+
+/**
+ * @brief Create an iterator finding all arguments matching criteria
+ *
+ * @note if neither @p ch or @p name is not given then this will return an
+ * iterator to every argument pair passed to the function.  If both are
+ * specified then this function will return any item matching either @p ch or
+ * @p name.
+ *
+ * @param[in]      argc                number of command line arguments
+ * @param[in]      argv                array of command line arguments
+ * @param[in,out]  iter                iterator object to initialize
+ * @param[in]      ch                  argument key to match (optional)
+ * @param[in]      name                argument name to match (optional)
+ *
+ * @retval         NULL                no matching arguments found
+ * @retval         !NULL               iterator to matching argument
+ *
+ * @see app_arg_find_next
+ * @see app_arg_iterator_key
+ * @see app_arg_iterator_value
+ */
+app_arg_iterator_t *app_arg_find(
+	int argc,
+	char **argv,
+	app_arg_iterator_t *iter,
+	char ch,
+	const char *name );
+
+/**
+ * @brief Finds the next item in the iterator
+ *
+ * @param[in]      argc                number of command line arguments
+ * @param[in]      argv                array of command line arguments
+ * @param[in,out]  iter                iterator object to increment
+ *
+ * @retval         NULL                no more matching arguments found
+ * @retval         !NULL               next matching argument
+ *
+ * @see app_arg_find
+ * @see app_arg_iterator_key
+ * @see app_arg_iterator_value
+ */
+app_arg_iterator_t *app_arg_find_next(
+	int argc,
+	char **argv,
+	app_arg_iterator_t *iter );
+
+/**
+ * @brief Returns the key for the item an iterator points to
+ *
+ * @param[in]      argc                number of command line arguments
+ * @param[in]      argv                array of command line arguments
+ * @param[in]      iter                iterator object to retrieve key for
+ * @param[out]     key_len             string length of the key (optional)
+ * @param[out]     key                 pointer to the key (optional)
+ *
+ * @retval         0                   on failure
+ * @retval         1                   on success
+ *
+ * @see app_arg_find
+ * @see app_arg_find_next
+ * @see app_arg_iterator_value
+ */
+int app_arg_iterator_key(
+	int argc,
+	char **argv,
+	const app_arg_iterator_t *iter,
+	size_t *key_len,
+	const char **key );
+
+/**
+ * @brief Returns the value for the item an iterator points to
+ *
+ * @param[in]      argc                number of command line arguments
+ * @param[in]      argv                array of command line arguments
+ * @param[in]      iter                iterator object to retrieve value for
+ * @param[out]     value_len           string length of the value (optional)
+ * @param[out]     value               pointer to the value (optional)
+ *
+ * @retval         0                   on failure
+ * @retval         1                   on success
+ *
+ * @see app_arg_find
+ * @see app_arg_find_next
+ * @see app_arg_iterator_key
+ */
+int app_arg_iterator_value(
+	int argc,
+	char **argv,
+	const app_arg_iterator_t *iter,
+	size_t *value_len,
+	const char **value );
 
 /**
  * @brief Parses arguments passed to the application

--- a/test/test-support/CMakeLists.txt
+++ b/test/test-support/CMakeLists.txt
@@ -14,9 +14,6 @@
 
 include( TestSupport )
 
-set_compiler_flag_if_supported(
-	"-Wno-disabled-macro-expansion" )
-
 add_test_library( test-support
 	"test_support.c"
 	"test_support.h"

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -38,4 +38,5 @@ add_subdirectory( "mock" )
 set( TEST_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}" )
 set( TEST_BINARY_DIR "${CMAKE_SOURCE_DIR}/src" )
 add_subdirectory( "api" )
+add_subdirectory( "utilities" )
 

--- a/test/unit/utilities/CMakeLists.txt
+++ b/test/unit/utilities/CMakeLists.txt
@@ -16,6 +16,7 @@ set( TARGET "utilities" )
 set( TESTS
 	"app_arg"
 	"app_log"
+	"app_path"
 )
 
 include( "mock_api" )
@@ -30,6 +31,11 @@ set( TEST_APP_LOG_MOCK ${MOCK_API_FUNC} ${MOCK_OSAL_FUNC} )
 set( TEST_APP_LOG_SRCS ${MOCK_API_SRCS} ${MOCK_OSAL_SRCS} "app_log_test.c" )
 set( TEST_APP_LOG_LIBS ${MOCK_API_LIBS} ${MOCK_OSAL_LIBS} )
 set( TEST_APP_LOG_UNIT "app_log.c" )
+
+set( TEST_APP_PATH_MOCK ${MOCK_OSAL_FUNC} )
+set( TEST_APP_PATH_SRCS ${MOCK_OSAL_SRCS} "app_path_test.c" )
+set( TEST_APP_PATH_LIBS ${MOCK_OSAL_LIBS} )
+set( TEST_APP_PATH_UNIT "app_path.c" )
 
 include( TestSupport )
 add_tests( ${TARGET} ${TESTS} )

--- a/test/unit/utilities/CMakeLists.txt
+++ b/test/unit/utilities/CMakeLists.txt
@@ -12,18 +12,18 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.
 #
 
-if( MSVC )
-	add_definitions( "/D_CRT_SECURE_NO_WARNINGS" )
-endif( MSVC )
+set( TARGET "utilities" )
+set( TESTS
+	"app_arg"
+)
 
-set_compiler_flag_if_supported(
-	"-Wno-bad-function-cast"
-	"-Wno-disabled-macro-expansion"
-	"-Wno-unused-parameter" )
+include( "mock_osal" )
 
-# Generate test support functions
-include_directories( "test-support" )
-add_subdirectory( "test-support" )
+set( TEST_APP_ARG_MOCK ${MOCK_OSAL_FUNC} )
+set( TEST_APP_ARG_SRCS ${MOCK_OSAL_SRCS} "app_arg_test.c" )
+set( TEST_APP_ARG_LIBS ${MOCK_OSAL_LIBS} )
+set( TEST_APP_ARG_UNIT "app_arg.c" )
 
-# Add unit tests
-add_subdirectory( "unit" )
+include( TestSupport )
+add_tests( ${TARGET} ${TESTS} )
+

--- a/test/unit/utilities/CMakeLists.txt
+++ b/test/unit/utilities/CMakeLists.txt
@@ -15,14 +15,21 @@
 set( TARGET "utilities" )
 set( TESTS
 	"app_arg"
+	"app_log"
 )
 
+include( "mock_api" )
 include( "mock_osal" )
 
 set( TEST_APP_ARG_MOCK ${MOCK_OSAL_FUNC} )
 set( TEST_APP_ARG_SRCS ${MOCK_OSAL_SRCS} "app_arg_test.c" )
 set( TEST_APP_ARG_LIBS ${MOCK_OSAL_LIBS} )
 set( TEST_APP_ARG_UNIT "app_arg.c" )
+
+set( TEST_APP_LOG_MOCK ${MOCK_API_FUNC} ${MOCK_OSAL_FUNC} )
+set( TEST_APP_LOG_SRCS ${MOCK_API_SRCS} ${MOCK_OSAL_SRCS} "app_log_test.c" )
+set( TEST_APP_LOG_LIBS ${MOCK_API_LIBS} ${MOCK_OSAL_LIBS} )
+set( TEST_APP_LOG_UNIT "app_log.c" )
 
 include( TestSupport )
 add_tests( ${TARGET} ${TESTS} )

--- a/test/unit/utilities/app_arg_test.c
+++ b/test/unit/utilities/app_arg_test.c
@@ -1,0 +1,577 @@
+/**
+ * @file
+ * @brief unit testing for common functions (argument parsing file)
+ *
+ * @copyright Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
+ *
+ * @license Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied."
+ */
+
+#include "test_support.h"
+
+#include "iot_build.h"
+#include "utilities/app_arg.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static const char *ARG_VALUE[] = { NULL, NULL, NULL, NULL, NULL, NULL };
+static const struct app_arg TEST_ARGS[] = {
+	{ '1', "one",           0u,    NULL,    NULL,          "one description",   1u },
+	{ '2', "two",           1u,    NULL,    NULL,          "two required",      2u },
+	{ '3', "three",         0u,    "arg",   &ARG_VALUE[0], "three description", 3u },
+	{ '4', "four",          0u,    NULL,    &ARG_VALUE[1], "four description",  4u },
+	{ '5', "five",          0u,    "[arg]", &ARG_VALUE[2], "five description",  5u },
+	{ '6', "six",           0u,    "[arg]", &ARG_VALUE[3], "six description",   6u },
+	{ '7', "seven",         0u,    "arg",   &ARG_VALUE[4], "seven description", 7u },
+	{ '8', "eight",         0u,    NULL,    NULL,          "eight description", 8u },
+	{ '9', "nine",          0u,    NULL,    NULL,          "nine description",  9u },
+	{ 0u,  "name-only",     0u,    NULL,    NULL,          "name-only #1",      10u },
+	{ 0u,  "name-required", 1u,    NULL,    NULL,          "name-only #2",      11u },
+	{ 0u,  "name-with-arg", 0u,    "arg",   &ARG_VALUE[5], "name-only #3",      12u },
+	{ 0u, NULL, 0, NULL, NULL, NULL, 0u }
+};
+
+
+/* static helper functions */
+static void* internal_struct_copy( const void* struct_ptr, size_t item_size,
+	size_t item_count )
+{
+	void *result = NULL;
+	void *out_ptr = NULL;
+	assert_non_null( struct_ptr );
+	if ( item_count > 0u )
+	{
+		result = test_calloc( item_count, item_size );
+		assert_non_null( result );
+		out_ptr = result;
+		while ( item_count > 0u )
+		{
+			memcpy( out_ptr, struct_ptr, item_size );
+			struct_ptr = (const char *)struct_ptr + item_size;
+			out_ptr = (char*)out_ptr + item_size;
+
+			--item_count;
+		}
+	}
+	return result;
+}
+
+static void internal_struct_free( void* struct_ptr )
+{
+	if ( struct_ptr )
+		test_free( struct_ptr );
+}
+
+static char** internal_args_allocate( const char **args, int argc )
+{
+	char **result = NULL;
+	if ( argc > 0 )
+	{
+		result = test_malloc( sizeof( char * ) * argc );
+		assert_non_null( result );
+	}
+	while ( argc > 0 )
+	{
+		size_t str_len;
+		--argc;
+		str_len = strlen( args[argc] ) + 1u;
+		result[argc] = test_malloc( str_len );
+		assert_non_null( result[argc] );
+		strncpy( result[argc], args[argc], str_len );
+	}
+	return result;
+}
+
+static void internal_args_free( char **args, int argc )
+{
+	if ( args )
+	{
+		while( argc > 0 )
+		{
+			--argc;
+			test_free( args[ argc ] );
+		}
+		test_free( args );
+	}
+}
+
+
+/* app_arg_count */
+static void test_app_arg_count_found_by_id( void **state )
+{
+	unsigned int result;
+
+	result = app_arg_count( TEST_ARGS, '3', NULL );
+	assert_int_equal( result, 3u );
+}
+
+static void test_app_arg_count_found_by_name( void **state )
+{
+	unsigned int result;
+
+	result = app_arg_count( TEST_ARGS, 0, "three" );
+	assert_int_equal( result, 3u );
+}
+
+static void test_app_arg_count_no_id_or_name( void **state )
+{
+	unsigned int result;
+
+	result = app_arg_count( TEST_ARGS, 0, NULL );
+	assert_int_equal( result, 0 );
+}
+
+static void test_app_arg_count_null_obj( void **state )
+{
+	unsigned int result;
+
+	result = app_arg_count( NULL, 'c', "count" );
+	assert_int_equal( result, 0 );
+}
+
+
+/* app_arg_parse */
+static void test_app_arg_parse_argument_expected_value( void **state )
+{
+	const char *args[] = { "/path/to/app", "-2", "--name-required",
+		"-3=three_value" };
+	int argc = sizeof( args ) / sizeof( const char * );
+	char **argv;
+	int result;
+
+	struct app_arg *opts =
+		(struct app_arg *)internal_struct_copy( TEST_ARGS,
+		sizeof( struct app_arg ),
+		sizeof( TEST_ARGS ) / sizeof( struct app_arg ) );
+	argv = internal_args_allocate( args, argc );
+
+	result = app_arg_parse( opts, argc, argv, NULL );
+	assert_int_equal( result, EXIT_SUCCESS );
+	assert_int_equal( opts[0].hit, 0u ); /* -1, --one */
+	assert_int_equal( opts[1].hit, 1u ); /* -2, --two */
+	assert_int_equal( opts[2].hit, 1u ); /* -3, --three */
+	assert_string_equal( ARG_VALUE[0], "three_value" );
+	assert_int_equal( opts[3].hit, 0u ); /* -4, --four */
+	assert_int_equal( opts[4].hit, 0u ); /* -5, --five */
+	assert_int_equal( opts[5].hit, 0u ); /* -6, --six */
+	assert_int_equal( opts[6].hit, 0u ); /* -7, --seven */
+	assert_int_equal( opts[7].hit, 0u ); /* -8, --eight */
+	assert_int_equal( opts[8].hit, 0u ); /* -9, --nine */
+	assert_int_equal( opts[9].hit, 0u ); /* --name-only */
+	assert_int_equal( opts[10].hit, 1u ); /* --name-required */
+	assert_int_equal( opts[11].hit, 0u ); /* --name-with-arg */
+
+	internal_struct_free( opts );
+	internal_args_free( argv, argc );
+}
+
+static void test_app_arg_parse_argument_no_value( void **state )
+{
+	const char *args[] = { "/path/to/app", "-2", "--name-required",
+		"--three" };
+	int argc = sizeof( args ) / sizeof( const char * );
+	char **argv;
+	int result;
+
+	struct app_arg *opts =
+		(struct app_arg *)internal_struct_copy( TEST_ARGS,
+		sizeof( struct app_arg ),
+		sizeof( TEST_ARGS ) / sizeof( struct app_arg ) );
+	argv = internal_args_allocate( args, argc );
+
+	result = app_arg_parse( opts, argc, argv, NULL );
+	assert_int_equal( result, EXIT_FAILURE );
+
+	internal_struct_free( opts );
+	internal_args_free( argv, argc );
+}
+
+static void test_app_arg_parse_argument_optional_not_specified( void **state )
+{
+	const char *args[] = { "/path/to/app", "-2", "--name-required",
+		"--five", "--six" };
+	int argc = sizeof( args ) / sizeof( const char * );
+	char **argv;
+	int result;
+
+	struct app_arg *opts =
+		(struct app_arg *)internal_struct_copy( TEST_ARGS,
+		sizeof( struct app_arg ),
+		sizeof( TEST_ARGS ) / sizeof( struct app_arg ) );
+	argv = internal_args_allocate( args, argc );
+
+	result = app_arg_parse( opts, argc, argv, NULL );
+	assert_int_equal( result, EXIT_SUCCESS );
+	assert_int_equal( opts[0].hit, 0u ); /* -1, --one */
+	assert_int_equal( opts[1].hit, 1u ); /* -2, --two */
+	assert_int_equal( opts[2].hit, 0u ); /* -3, --three */
+	assert_int_equal( opts[3].hit, 0u ); /* -4, --four */
+	assert_int_equal( opts[4].hit, 1u ); /* -5, --five */
+	assert_null( ARG_VALUE[2] );
+	assert_int_equal( opts[5].hit, 1u ); /* -6, --six */
+	assert_int_equal( opts[6].hit, 0u ); /* -7, --seven */
+	assert_int_equal( opts[7].hit, 0u ); /* -8, --eight */
+	assert_int_equal( opts[8].hit, 0u ); /* -9, --nine */
+	assert_int_equal( opts[9].hit, 0u ); /* --name-only */
+	assert_int_equal( opts[10].hit, 1u ); /* --name-required */
+	assert_int_equal( opts[11].hit, 0u ); /* --name-with-arg */
+
+	internal_struct_free( opts );
+	internal_args_free( argv, argc );
+}
+
+static void test_app_arg_parse_argument_optional_specified( void **state )
+{
+	const char *args[] = { "/path/to/app", "-2", "--name-required",
+		"--five", "five_value" };
+	int argc = sizeof( args ) / sizeof( const char * );
+	char **argv;
+	int result;
+
+	struct app_arg *opts =
+		(struct app_arg *)internal_struct_copy( TEST_ARGS,
+		sizeof( struct app_arg ),
+		sizeof( TEST_ARGS ) / sizeof( struct app_arg ) );
+	argv = internal_args_allocate( args, argc );
+
+	result = app_arg_parse( opts, argc, argv, NULL );
+	assert_int_equal( result, EXIT_SUCCESS );
+	assert_int_equal( opts[0].hit, 0u ); /* -1, --one */
+	assert_int_equal( opts[1].hit, 1u ); /* -2, --two */
+	assert_int_equal( opts[2].hit, 0u ); /* -3, --three */
+	assert_int_equal( opts[3].hit, 0u ); /* -4, --four */
+	assert_int_equal( opts[4].hit, 1u ); /* -5, --five */
+	assert_string_equal( ARG_VALUE[2], "five_value" );
+	assert_int_equal( opts[5].hit, 0u ); /* -6, --six */
+	assert_int_equal( opts[6].hit, 0u ); /* -7, --seven */
+	assert_int_equal( opts[7].hit, 0u ); /* -8, --eight */
+	assert_int_equal( opts[8].hit, 0u ); /* -9, --nine */
+	assert_int_equal( opts[9].hit, 0u ); /* --name-only */
+	assert_int_equal( opts[10].hit, 1u ); /* --name-required */
+	assert_int_equal( opts[11].hit, 0u ); /* --name-with-arg */
+
+	internal_struct_free( opts );
+	internal_args_free( argv, argc );
+}
+
+static void test_app_arg_parse_argument_optional_specified_twice( void **state )
+{
+	const char *args[] = { "/path/to/app", "-2", "--name-required",
+		"--five", "five_value", "five_value2" };
+	int argc = sizeof( args ) / sizeof( const char * );
+	char **argv;
+	int result;
+
+	struct app_arg *opts =
+		(struct app_arg *)internal_struct_copy( TEST_ARGS,
+		sizeof( struct app_arg ),
+		sizeof( TEST_ARGS ) / sizeof( struct app_arg ) );
+	argv = internal_args_allocate( args, argc );
+
+	result = app_arg_parse( opts, argc, argv, NULL );
+	assert_int_equal( result, EXIT_FAILURE );
+
+	internal_struct_free( opts );
+	internal_args_free( argv, argc );
+}
+
+static void test_app_arg_parse_argument_required( void **state )
+{
+	const char *args[] = { "/path/to/app", "-2", "--name-required",
+		"--seven", "--eight" };
+	int argc = sizeof( args ) / sizeof( const char * );
+	char **argv;
+	int result;
+
+	struct app_arg *opts =
+		(struct app_arg *)internal_struct_copy( TEST_ARGS,
+		sizeof( struct app_arg ),
+		sizeof( TEST_ARGS ) / sizeof( struct app_arg ) );
+	argv = internal_args_allocate( args, argc );
+
+	result = app_arg_parse( opts, argc, argv, NULL );
+	assert_int_equal( result, EXIT_FAILURE );
+
+	internal_struct_free( opts );
+	internal_args_free( argv, argc );
+}
+
+static void test_app_arg_parse_argument_unexpected_value( void **state )
+{
+	const char *args[] = { "/path/to/app", "-2", "--name-required",
+		"-8=eight_value" };
+	int argc = sizeof( args ) / sizeof( const char * );
+	char **argv;
+	int result;
+
+	struct app_arg *opts =
+		(struct app_arg *)internal_struct_copy( TEST_ARGS,
+		sizeof( struct app_arg ),
+		sizeof( TEST_ARGS ) / sizeof( struct app_arg ) );
+	argv = internal_args_allocate( args, argc );
+
+	result = app_arg_parse( opts, argc, argv, NULL );
+	assert_int_equal( result, EXIT_FAILURE );
+
+	internal_struct_free( opts );
+	internal_args_free( argv, argc );
+}
+
+static void test_app_arg_parse_argument_unknown_dash( void **state )
+{
+	const char *args[] = { "/path/to/app", "-2", "--name-required",
+		"--unknown-arg" };
+	int argc = sizeof( args ) / sizeof( const char * );
+	char **argv;
+	int result;
+
+	struct app_arg *opts =
+		(struct app_arg *)internal_struct_copy( TEST_ARGS,
+		sizeof( struct app_arg ),
+		sizeof( TEST_ARGS ) / sizeof( struct app_arg ) );
+	argv = internal_args_allocate( args, argc );
+
+	result = app_arg_parse( opts, argc, argv, NULL );
+	assert_int_equal( result, EXIT_FAILURE );
+
+	internal_struct_free( opts );
+	internal_args_free( argv, argc );
+}
+
+static void test_app_arg_parse_argument_unknown_no_dash( void **state )
+{
+	const char *args[] = { "/path/to/app", "-2", "--name-required",
+		"unknown-arg" };
+	int argc = sizeof( args ) / sizeof( const char * );
+	char **argv;
+	int result;
+
+	struct app_arg *opts =
+		(struct app_arg *)internal_struct_copy( TEST_ARGS,
+		sizeof( struct app_arg ),
+		sizeof( TEST_ARGS ) / sizeof( struct app_arg ) );
+	argv = internal_args_allocate( args, argc );
+
+	result = app_arg_parse( opts, argc, argv, NULL );
+	assert_int_equal( result, EXIT_FAILURE );
+
+	internal_struct_free( opts );
+	internal_args_free( argv, argc );
+}
+
+static void test_app_arg_parse_missing_required( void **state )
+{
+	const char *args[] = { "/path/to/app", "-2" };
+	int argc = sizeof( args ) / sizeof( const char * );
+	char **argv;
+	int pos = 0u;
+	int result;
+
+	struct app_arg *opts =
+		(struct app_arg *)internal_struct_copy( TEST_ARGS,
+		sizeof( struct app_arg ),
+		sizeof( TEST_ARGS ) / sizeof( struct app_arg ) );
+	argv = internal_args_allocate( args, argc );
+
+	result = app_arg_parse( opts, argc, argv, &pos );
+	assert_int_equal( result, EXIT_FAILURE );
+
+	internal_struct_free( opts );
+	internal_args_free( argv, argc );
+}
+
+static void test_app_arg_parse_mulitple( void **state )
+{
+	const char *args[] = { "/path/to/app", "--name-required",
+		"-2", "-2", "-2", "-2", "-2", "-2", "-2" };
+	int argc = sizeof( args ) / sizeof( const char * );
+	char **argv;
+	int pos = 0u;
+	int result;
+
+	struct app_arg *opts =
+		(struct app_arg *)internal_struct_copy( TEST_ARGS,
+		sizeof( struct app_arg ),
+		sizeof( TEST_ARGS ) / sizeof( struct app_arg ) );
+	argv = internal_args_allocate( args, argc );
+
+	result = app_arg_parse( opts, argc, argv, &pos );
+	assert_int_equal( result, EXIT_SUCCESS );
+	assert_int_equal( opts[0].hit, 0u ); /* -1, --one */
+	assert_int_equal( opts[1].hit, 7u ); /* -2, --two */
+	assert_int_equal( opts[2].hit, 0u ); /* -3, --three */
+	assert_int_equal( opts[3].hit, 0u ); /* -4, --four */
+	assert_int_equal( opts[4].hit, 0u ); /* -5, --five */
+	assert_int_equal( opts[5].hit, 0u ); /* -6, --six */
+	assert_int_equal( opts[6].hit, 0u ); /* -7, --seven */
+	assert_int_equal( opts[7].hit, 0u ); /* -8, --eight */
+	assert_int_equal( opts[8].hit, 0u ); /* -9, --nine */
+	assert_int_equal( opts[9].hit, 0u ); /* --name-only */
+	assert_int_equal( opts[10].hit, 1u ); /* --name-required */
+	assert_int_equal( opts[11].hit, 0u ); /* --name-with-arg */
+
+	internal_struct_free( opts );
+	internal_args_free( argv, argc );
+}
+
+static void test_app_arg_parse_null_obj( void **state )
+{
+	const char *args[] = { "/path/to/app" };
+	int argc = sizeof( args ) / sizeof( const char * );
+	char **argv;
+	int pos = 0u;
+	int result;
+
+	argv = internal_args_allocate( args, argc );
+
+	result = app_arg_parse( NULL, argc, argv, &pos );
+	assert_int_equal( result, EXIT_SUCCESS );
+
+	internal_args_free( argv, argc );
+}
+
+static void test_app_arg_parse_no_args( void **state )
+{
+	const char *args[] = { "/path/to/app" };
+	int argc = sizeof( args ) / sizeof( const char * );
+	char **argv;
+	int pos = 0u;
+	int result;
+
+	struct app_arg *opts =
+		(struct app_arg *)internal_struct_copy( TEST_ARGS,
+		sizeof( struct app_arg ),
+		sizeof( TEST_ARGS ) / sizeof( struct app_arg ) );
+	argv = internal_args_allocate( args, argc );
+
+	result = app_arg_parse( opts, argc, argv, &pos );
+	assert_int_equal( result, EXIT_FAILURE );
+
+	internal_struct_free( opts );
+	internal_args_free( argv, argc );
+}
+
+
+/* app_arg_usage */
+static void test_app_arg_usage_null_obj( void **state )
+{
+	app_arg_usage( NULL, 10u, "app name", "app description",
+		"pos_id", "positional argument description" );
+	/* above function shouldn't crash */
+	assert_true( 1 );
+}
+
+static void test_app_arg_usage_null_app_description( void **state )
+{
+	app_arg_usage( TEST_ARGS, 10u, "app name", NULL,
+		"pos_id", "positional argument description" );
+	/* above function shouldn't crash */
+	assert_true( 1 );
+}
+
+static void test_app_arg_usage_null_app_name( void **state )
+{
+	app_arg_usage( TEST_ARGS, 10u, NULL, "app description",
+		"pos_id", "positional argument description" );
+	/* above function shouldn't crash */
+	assert_true( 1 );
+}
+
+static void test_app_arg_usage_null_positional_name( void **state )
+{
+	app_arg_usage( TEST_ARGS, 10u, "app name", "app description",
+		NULL, "positional argument description" );
+	/* above function shouldn't crash */
+	assert_true( 1 );
+}
+
+static void test_app_arg_usage_null_positional_description( void **state )
+{
+	app_arg_usage( TEST_ARGS, 20u, "path/to/app", "app description",
+		"pos_id", NULL );
+	/* above function shouldn't crash */
+	assert_true( 1 );
+}
+
+static void test_app_arg_usage_positional_name_multi( void **state )
+{
+	app_arg_usage( TEST_ARGS, 20u, "path/to/app", "app description",
+		"pos_id+", "positional argument description" );
+	/* above function shouldn't crash */
+	assert_true( 1 );
+}
+
+static void test_app_arg_usage_positional_name_multi_optional( void **state )
+{
+	app_arg_usage( TEST_ARGS, 20u, "path/to/app", "app description",
+		"[pos_id]+", "positional argument description" );
+	/* above function shouldn't crash */
+	assert_true( 1 );
+}
+
+static void test_app_arg_usage_positional_name_optional( void **state )
+{
+	app_arg_usage( TEST_ARGS, 20u, "path/to/app", "app description",
+		"[pos_id]", "positional argument description" );
+	/* above function shouldn't crash */
+	assert_true( 1 );
+}
+
+static void test_app_arg_usage_positional_name_single( void **state )
+{
+	app_arg_usage( TEST_ARGS, 200u, "path/to/app", "app description",
+		"pos_id", "positional argument description" );
+	/* above function shouldn't crash */
+	assert_true( 1 );
+}
+
+
+/* main */
+int main( int argc, char* argv[] )
+{
+	int result;
+	const struct CMUnitTest tests[] =
+	{
+		cmocka_unit_test( test_app_arg_count_found_by_id ),
+		cmocka_unit_test( test_app_arg_count_found_by_name ),
+		cmocka_unit_test( test_app_arg_count_no_id_or_name ),
+		cmocka_unit_test( test_app_arg_count_null_obj ),
+		cmocka_unit_test( test_app_arg_parse_argument_expected_value ),
+		cmocka_unit_test( test_app_arg_parse_argument_no_value ),
+		cmocka_unit_test( test_app_arg_parse_argument_optional_not_specified ),
+		cmocka_unit_test( test_app_arg_parse_argument_optional_specified ),
+		cmocka_unit_test( test_app_arg_parse_argument_optional_specified_twice ),
+		cmocka_unit_test( test_app_arg_parse_argument_required ),
+		cmocka_unit_test( test_app_arg_parse_argument_unexpected_value ),
+		cmocka_unit_test( test_app_arg_parse_argument_unknown_dash ),
+		cmocka_unit_test( test_app_arg_parse_argument_unknown_no_dash ),
+		cmocka_unit_test( test_app_arg_parse_missing_required ),
+		cmocka_unit_test( test_app_arg_parse_mulitple ),
+		cmocka_unit_test( test_app_arg_parse_null_obj ),
+		cmocka_unit_test( test_app_arg_parse_no_args ),
+		cmocka_unit_test( test_app_arg_usage_null_obj ),
+		cmocka_unit_test( test_app_arg_usage_null_app_name ),
+		cmocka_unit_test( test_app_arg_usage_null_app_description ),
+		cmocka_unit_test( test_app_arg_usage_null_app_name ),
+		cmocka_unit_test( test_app_arg_usage_null_positional_name ),
+		cmocka_unit_test( test_app_arg_usage_null_positional_description ),
+		cmocka_unit_test( test_app_arg_usage_positional_name_multi ),
+		cmocka_unit_test( test_app_arg_usage_positional_name_optional ),
+		cmocka_unit_test( test_app_arg_usage_positional_name_optional ),
+		cmocka_unit_test( test_app_arg_usage_positional_name_single ),
+	};
+	MOCK_SYSTEM_ENABLED = 1;
+	result = cmocka_run_group_tests( tests, NULL, NULL );
+	MOCK_SYSTEM_ENABLED = 0;
+	return result;
+}
+

--- a/test/unit/utilities/app_log_test.c
+++ b/test/unit/utilities/app_log_test.c
@@ -1,0 +1,143 @@
+/**
+ * @file
+ * @brief unit testing for logging utilities
+ *
+ * @copyright Copyright (C) 2016-2018 Wind River Systems, Inc. All Rights Reserved.
+ *
+ * @license Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied."
+ */
+
+#include "test_support.h"
+
+#include "iot_build.h"
+#include "utilities/app_log.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static void test_app_log( void** state )
+{
+	iot_log_level_t log_level;
+	iot_log_source_t source;
+	const char *message_1 = "test message 1";
+	const char *message_2 = "test message 2";
+	const char *message_3 = "test message 3";
+	const char *message_4 = "test message 4";
+	const char *message_5 = "test message 5";
+
+	log_level = IOT_LOG_CRITICAL;
+	source.file_name = "test_file";
+	source.function_name = "test_file";
+	source.line_number = 100u;
+
+	will_return( __wrap_os_terminal_vt100_support, IOT_TRUE );
+	app_log( log_level, &source, message_1, NULL );
+	app_log( log_level, &source, message_1, NULL );
+	app_log( log_level, &source, message_1, NULL );
+
+	log_level = IOT_LOG_NOTICE;
+	will_return( __wrap_os_terminal_vt100_support, IOT_TRUE );
+	app_log( log_level, &source, message_2, NULL );
+	log_level = IOT_LOG_INFO;
+	will_return( __wrap_os_terminal_vt100_support, IOT_TRUE );
+	app_log( log_level, &source, message_3, NULL );
+	log_level = IOT_LOG_DEBUG;
+	will_return( __wrap_os_terminal_vt100_support, IOT_TRUE );
+	app_log( log_level, &source, message_4, NULL );
+	log_level = IOT_LOG_TRACE;
+	will_return( __wrap_os_terminal_vt100_support, IOT_TRUE );
+	app_log( log_level, &source, message_5, NULL );
+}
+
+static void test_app_log_filename_with_path( void** state )
+{
+	iot_log_level_t log_level;
+	iot_log_source_t source;
+	const char *message_1 = "test message 1";
+	const char *message_2 = "test message 2";
+	const char *message_3 = "test message 3";
+	const char *message_4 = "test message 4";
+	const char *message_5 = "test message 5";
+
+	log_level = IOT_LOG_CRITICAL;
+	source.file_name = "/a/b/c/test_file";
+	source.function_name = "test_file";
+	source.line_number = 100u;
+
+	will_return( __wrap_os_terminal_vt100_support, IOT_TRUE );
+	app_log( log_level, &source, message_1, NULL );
+	app_log( log_level, &source, message_1, NULL );
+	app_log( log_level, &source, message_1, NULL );
+
+	log_level = IOT_LOG_NOTICE;
+	will_return( __wrap_os_terminal_vt100_support, IOT_TRUE );
+	app_log( log_level, &source, message_2, NULL );
+	log_level = IOT_LOG_INFO;
+	will_return( __wrap_os_terminal_vt100_support, IOT_TRUE );
+	app_log( log_level, &source, message_3, NULL );
+	log_level = IOT_LOG_DEBUG;
+	will_return( __wrap_os_terminal_vt100_support, IOT_TRUE );
+	app_log( log_level, &source, message_4, NULL );
+	log_level = IOT_LOG_TRACE;
+	will_return( __wrap_os_terminal_vt100_support, IOT_TRUE );
+	app_log( log_level, &source, message_5, NULL );
+}
+
+static void test_app_log_no_vt100( void** state )
+{
+	iot_log_level_t log_level;
+	iot_log_source_t source;
+	const char *message_1 = "test message 1";
+	const char *message_2 = "test message 2";
+	const char *message_3 = "test message 3";
+	const char *message_4 = "test message 4";
+	const char *message_5 = "test message 5";
+
+	log_level = IOT_LOG_CRITICAL;
+	source.file_name = "test_file";
+	source.function_name = "test_file";
+	source.line_number = 100u;
+
+	will_return( __wrap_os_terminal_vt100_support, IOT_FALSE );
+	app_log( log_level, &source, message_1, NULL );
+	app_log( log_level, &source, message_1, NULL );
+	app_log( log_level, &source, message_1, NULL );
+
+	log_level = IOT_LOG_NOTICE;
+	will_return( __wrap_os_terminal_vt100_support, IOT_FALSE );
+	app_log( log_level, &source, message_2, NULL );
+	log_level = IOT_LOG_INFO;
+	will_return( __wrap_os_terminal_vt100_support, IOT_FALSE );
+	app_log( log_level, &source, message_3, NULL );
+	log_level = IOT_LOG_DEBUG;
+	will_return( __wrap_os_terminal_vt100_support, IOT_FALSE );
+	app_log( log_level, &source, message_4, NULL );
+	log_level = IOT_LOG_TRACE;
+	will_return( __wrap_os_terminal_vt100_support, IOT_FALSE );
+	app_log( log_level, &source, message_5, NULL );
+}
+
+/* main */
+int main( int argc, char* argv[] )
+{
+	int result;
+	const struct CMUnitTest tests[] =
+	{
+		cmocka_unit_test( test_app_log ),
+		cmocka_unit_test( test_app_log_filename_with_path ),
+		cmocka_unit_test( test_app_log_no_vt100 )
+	};
+	MOCK_SYSTEM_ENABLED = 1;
+	result = cmocka_run_group_tests( tests, NULL, NULL );
+	MOCK_SYSTEM_ENABLED = 0;
+	return result;
+}
+

--- a/test/unit/utilities/app_path_test.c
+++ b/test/unit/utilities/app_path_test.c
@@ -1,0 +1,483 @@
+/**
+ * @file
+ * @brief unit testing for common functions (path conversion functions)
+ *
+ * @copyright Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
+ *
+ * @license Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied."
+ */
+
+#include "test_support.h"
+
+#include "iot_build.h"
+#include "utilities/app_path.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static void test_app_path_make_absolute_cur_dir_buff_too_small( void **state )
+{
+	size_t result;
+	char path[ 64u ];
+	const char *expected_path;
+	strncpy( path, "file_to_find.c", 64u );
+	expect_string( __wrap_os_path_is_absolute, path, "file_to_find.c" );
+	will_return( __wrap_os_path_is_absolute, IOT_FALSE );
+#ifdef _WIN32
+	will_return( __wrap_os_directory_current, "C:\\" IOT_BIN_DIR );
+	expected_path = "C:\\" IOT_BIN_DIR "\\file_to_find.c";
+#else
+	will_return( __wrap_os_directory_current, "/usr/" IOT_BIN_DIR );
+	expected_path = "/usr/" IOT_BIN_DIR "/file_to_find.c";
+#endif
+	/* too small by 1 character (null-terminator) */
+	result = app_path_make_absolute( path, strlen( expected_path ),
+		IOT_FALSE );
+
+	assert_int_equal( result, strlen( expected_path ) );
+
+	/* should not change the buffer */
+	assert_string_equal( path, "file_to_find.c" );
+}
+
+static void test_app_path_make_absolute_cur_dir_failed( void **state )
+{
+	size_t result;
+	char path[ 64u ];
+	strncpy( path, "file_to_find.c", 64u );
+	expect_string( __wrap_os_path_is_absolute, path, "file_to_find.c" );
+	will_return( __wrap_os_path_is_absolute, IOT_FALSE );
+	will_return( __wrap_os_directory_current, NULL );
+	result = app_path_make_absolute( path, 64u, IOT_FALSE );
+
+	assert_int_equal( result, 0u );
+	assert_string_equal( path, "file_to_find.c" );
+}
+
+static void test_app_path_make_absolute_cur_dir_valid_with_sep( void **state )
+{
+	size_t result;
+	char path[ 64u ];
+	const char *expected_path;
+	strncpy( path, "file_to_find.c", 64u );
+	expect_string( __wrap_os_path_is_absolute, path, "file_to_find.c" );
+	will_return( __wrap_os_path_is_absolute, IOT_FALSE );
+#ifdef _WIN32
+	will_return( __wrap_os_directory_current, "C:\\" IOT_BIN_DIR "\\" );
+	expected_path = "C:\\" IOT_BIN_DIR "\\file_to_find.c";
+#else
+	will_return( __wrap_os_directory_current, "/usr/" IOT_BIN_DIR "/" );
+	expected_path = "/usr/" IOT_BIN_DIR "/file_to_find.c";
+#endif
+	result = app_path_make_absolute( path, 64u, IOT_FALSE );
+
+	assert_int_equal( result, strlen( expected_path ) );
+	assert_string_equal( path, expected_path );
+}
+
+static void test_app_path_make_absolute_cur_dir_valid_without_sep( void **state )
+{
+	size_t result;
+	char path[ 64u ];
+	const char *expected_path;
+	strncpy( path, "file_to_find.c", 64u );
+	expect_string( __wrap_os_path_is_absolute, path, "file_to_find.c" );
+	will_return( __wrap_os_path_is_absolute, IOT_FALSE );
+	will_return( __wrap_os_directory_current, IOT_BIN_DIR );
+#ifdef _WIN32
+	expected_path = IOT_BIN_DIR "\\file_to_find.c";
+#else
+	expected_path = IOT_BIN_DIR "/file_to_find.c";
+#endif
+	result = app_path_make_absolute( path, 64u, IOT_FALSE );
+
+	assert_int_equal( result, strlen( expected_path ) );
+	assert_string_equal( path, expected_path );
+}
+
+static void test_app_path_make_absolute_null_path( void **state )
+{
+	size_t result;
+	result = app_path_make_absolute( NULL, 0u, IOT_FALSE );
+	assert_int_equal( result, 0u );
+	result = app_path_make_absolute( NULL, 0u, IOT_TRUE );
+	assert_int_equal( result, 0u );
+}
+
+static void test_app_path_make_absolute_pass_absolute_path( void **state )
+{
+	char path[ 64u ];
+	const char *expected_path;
+	size_t result;
+#ifdef _WIN32
+	strncpy( path, "C:\\Program Files (x86)\\file_to_find.c", 64u );
+	expected_path = "C:\\Program Files (x86)\\file_to_find.c";
+#else
+	strncpy( path, "/usr/bin/file_to_find.c", 64u );
+	expected_path = "/usr/bin/file_to_find.c";
+#endif
+	expect_string( __wrap_os_path_is_absolute, path, expected_path );
+	will_return( __wrap_os_path_is_absolute, IOT_TRUE );
+	result = app_path_make_absolute( path, 64u, IOT_FALSE );
+
+	assert_int_equal( result, strlen( expected_path ) );
+	assert_string_equal( path, expected_path );
+}
+
+static void test_app_path_make_absolute_relative_buff_too_small( void **state )
+{
+	size_t result;
+	char path[ 64u ];
+	const char *expected_path;
+	strncpy( path, "file_to_find.c", 64u );
+	expect_string( __wrap_os_path_is_absolute, path, "file_to_find.c" );
+	will_return( __wrap_os_path_is_absolute, IOT_FALSE );
+#ifdef _WIN32
+	will_return( __wrap_os_path_executable, "C:\\" IOT_BIN_DIR "\\my_app" );
+	/* note: IOT_BIN_DIR (is removed) */
+	expected_path = "C:\\file_to_find.c";
+#else
+	will_return( __wrap_os_path_executable, "/usr/" IOT_BIN_DIR "/my_app" );
+	/* note: IOT_BIN_DIR (is removed) */
+	expected_path = "/usr/file_to_find.c";
+#endif
+	/* too small by 1 character (null-terminator) */
+	result = app_path_make_absolute( path, strlen( expected_path ),
+		IOT_TRUE );
+
+	assert_int_equal( result, strlen( expected_path ) );
+
+	/* should not change the buffer */
+	assert_string_equal( path, "file_to_find.c" );
+}
+
+static void test_app_path_make_absolute_relative_failed( void **state )
+{
+	size_t result;
+	char path[ 64u ];
+	strncpy( path, "file_to_find.c", 64u );
+	expect_string( __wrap_os_path_is_absolute, path, "file_to_find.c" );
+	will_return( __wrap_os_path_is_absolute, IOT_FALSE );
+	will_return( __wrap_os_path_executable, NULL );
+	result = app_path_make_absolute( path, 64u, IOT_TRUE );
+
+	assert_int_equal( result, 0u );
+	assert_string_equal( path, "file_to_find.c" );
+}
+
+static void test_app_path_make_absolute_relative_valid_with_sep( void **state )
+{
+	size_t result;
+	char path[ 64u ];
+	const char *expected_path;
+	strncpy( path, "file_to_find.c", 64u );
+	expect_string( __wrap_os_path_is_absolute, path, "file_to_find.c" );
+	will_return( __wrap_os_path_is_absolute, IOT_FALSE );
+#ifdef _WIN32
+	will_return( __wrap_os_path_executable, "C:\\" IOT_BIN_DIR "\\my_app" );
+	/* note: IOT_BIN_DIR (is removed) */
+	expected_path = "C:\\file_to_find.c";
+#else
+	will_return( __wrap_os_path_executable, "/usr/" IOT_BIN_DIR "/my_app" );
+	/* note: IOT_BIN_DIR (is removed) */
+	expected_path = "/usr/file_to_find.c";
+#endif
+	result = app_path_make_absolute( path, 64u, IOT_TRUE );
+
+	assert_int_equal( result, strlen( expected_path ) );
+	assert_string_equal( path, expected_path );
+}
+
+static void test_app_path_make_absolute_relative_valid_without_sep( void **state )
+{
+	char path[ 64u ];
+	const char *expected_path;
+	size_t result;
+	strncpy( path, "file_to_find.c", 64u );
+	expect_string( __wrap_os_path_is_absolute, path, "file_to_find.c" );
+	will_return( __wrap_os_path_is_absolute, IOT_FALSE );
+	will_return( __wrap_os_path_executable, "my_app" );
+	expected_path = "file_to_find.c";
+	result = app_path_make_absolute( path, 64u, IOT_TRUE );
+
+	assert_int_equal( result, strlen( expected_path ) );
+	assert_string_equal( path, expected_path );
+}
+
+static void test_app_path_which_null_file( void **state )
+{
+	size_t result;
+	char path[ 123u ];
+
+	*path = '\0';
+	result = app_path_which( path, 123u, NULL, NULL );
+	assert_int_equal( result, 0u );
+	assert_string_equal( path, "" );
+}
+
+static void test_app_path_which_null_path_exists( void **state )
+{
+	size_t result;
+
+	will_return( __wrap_os_make_path, "./test_file" );
+	will_return( __wrap_os_file_exists, IOT_TRUE );
+#ifdef _WIN32
+	will_return( __wrap_os_env_get, "C:\\Windows;C:\\Windows\\bin" );
+#else
+	will_return( __wrap_os_env_get, "/usr/bin:/usr/local/bin" );
+#endif
+	will_return( __wrap_os_env_get, "" );
+	result = app_path_which( NULL, 0u, NULL, "test_file" );
+	assert_int_equal( result, 11u );
+}
+
+static void test_app_path_which_null_path_no_env_vars( void **state )
+{
+	size_t result;
+
+	will_return( __wrap_os_env_get, NULL );
+	will_return( __wrap_os_env_get, NULL );
+	will_return( __wrap_os_make_path, "./test_file" );
+	will_return( __wrap_os_file_exists, IOT_FALSE );
+	result = app_path_which( NULL, 0u, NULL, "test_file" );
+	assert_int_equal( result, 0u );
+}
+
+static void test_app_path_which_null_path_not_found( void **state )
+{
+	size_t result;
+
+#ifdef _WIN32
+	will_return( __wrap_os_env_get, "C:\\Windows;C:\\Windows\\bin" );
+#else
+	will_return( __wrap_os_env_get, "/usr/local:/usr/local/bin" );
+#endif
+	will_return( __wrap_os_env_get, "" );
+	will_return( __wrap_os_make_path, "./test_file" );
+	will_return( __wrap_os_file_exists, IOT_FALSE );
+	will_return( __wrap_os_make_path, "/usr/local/test_file" );
+	will_return( __wrap_os_file_exists, IOT_FALSE );
+	will_return( __wrap_os_make_path, "/usr/local/bin/test_file" );
+	will_return( __wrap_os_file_exists, IOT_FALSE );
+	result = app_path_which( NULL, 0u, NULL, "test_file" );
+	assert_int_equal( result, 0u );
+}
+
+static void test_app_path_which_null_path_only_exts( void **state )
+{
+	size_t result;
+
+	will_return( __wrap_os_env_get, "" );
+#ifdef _WIN32
+	will_return( __wrap_os_env_get, ".bat;com;.exe" );
+#else
+	will_return( __wrap_os_env_get, ".bat:com:.exe" );
+#endif
+	will_return( __wrap_os_make_path, "./test_file" );
+	will_return( __wrap_os_file_exists, IOT_FALSE );
+	will_return( __wrap_os_make_path, "./test_file.bat" );
+	will_return( __wrap_os_file_exists, IOT_FALSE );
+	will_return( __wrap_os_make_path, "./test_file.com" );
+	will_return( __wrap_os_file_exists, IOT_FALSE );
+	will_return( __wrap_os_make_path, "./test_file.exe" );
+	will_return( __wrap_os_file_exists, IOT_TRUE );
+	result = app_path_which( NULL, 0u, NULL, "test_file" );
+	assert_int_equal( result, 15u );
+}
+
+static void test_app_path_which_null_path_only_paths( void **state )
+{
+	size_t result;
+
+#ifdef _WIN32
+	will_return( __wrap_os_env_get, "C:\\Windows;C:\\Windows\\bin" );
+#else
+	will_return( __wrap_os_env_get, "/usr/local:/usr/local/bin" );
+#endif
+	will_return( __wrap_os_env_get, "" );
+	will_return( __wrap_os_make_path, "./test_file" );
+	will_return( __wrap_os_file_exists, IOT_FALSE );
+	will_return( __wrap_os_make_path, "/usr/local/test_file" );
+	will_return( __wrap_os_file_exists, IOT_TRUE );
+	result = app_path_which( NULL, 0u, NULL, "test_file" );
+	assert_int_equal( result, 20u );
+}
+
+static void test_app_path_which_out_path_exists( void **state )
+{
+	size_t result;
+	char out[ 25u ];
+
+	will_return( __wrap_os_make_path, "./test_file" );
+	will_return( __wrap_os_file_exists, IOT_TRUE );
+#ifdef _WIN32
+	will_return( __wrap_os_env_get, "/usr/bin;/usr/local/bin" );
+#else
+	will_return( __wrap_os_env_get, "/usr/bin:/usr/local/bin" );
+#endif
+	will_return( __wrap_os_env_get, "" );
+	result = app_path_which( out, 25u, NULL, "test_file" );
+	assert_int_equal( result, 11u );
+	assert_string_equal( out, "./test_file" );
+}
+
+static void test_app_path_which_out_path_no_env_vars( void **state )
+{
+	size_t result;
+	char out[ 25u ];
+
+	will_return( __wrap_os_env_get, NULL );
+	will_return( __wrap_os_env_get, NULL );
+	will_return( __wrap_os_make_path, "./test_file" );
+	will_return( __wrap_os_file_exists, IOT_FALSE );
+	result = app_path_which( out, 25u, NULL, "test_file" );
+	assert_int_equal( result, 0u );
+	assert_string_equal( out, "" );
+}
+
+static void test_app_path_which_out_path_not_found( void **state )
+{
+	size_t result;
+	char out[ 25u ];
+
+#ifdef _WIN32
+	will_return( __wrap_os_env_get, "C:\\Windows;C:\\Windows\\System32" );
+#else
+	will_return( __wrap_os_env_get, "/usr/local:/usr/local/bin" );
+#endif
+	will_return( __wrap_os_env_get, "" );
+	will_return( __wrap_os_make_path, "./test_file" );
+	will_return( __wrap_os_file_exists, IOT_FALSE );
+	will_return( __wrap_os_make_path, "/usr/local/test_file" );
+	will_return( __wrap_os_file_exists, IOT_FALSE );
+	will_return( __wrap_os_make_path, "/usr/local/bin/test_file" );
+	will_return( __wrap_os_file_exists, IOT_FALSE );
+	result = app_path_which( out, 25u, NULL, "test_file" );
+	assert_int_equal( result, 0u );
+	assert_string_equal( out, "" );
+}
+
+static void test_app_path_which_out_path_only_exts( void **state )
+{
+	size_t result;
+	char out[ 25u ];
+
+	will_return( __wrap_os_env_get, "" );
+#ifdef _WIN32
+	will_return( __wrap_os_env_get, ".bat;com;.exe" );
+#else
+	will_return( __wrap_os_env_get, ".bat:com:.exe" );
+#endif
+	will_return( __wrap_os_make_path, "./test_file" );
+	will_return( __wrap_os_file_exists, IOT_FALSE );
+	will_return( __wrap_os_make_path, "./test_file.bat" );
+	will_return( __wrap_os_file_exists, IOT_FALSE );
+	will_return( __wrap_os_make_path, "./test_file.com" );
+	will_return( __wrap_os_file_exists, IOT_FALSE );
+	will_return( __wrap_os_make_path, "./test_file.exe" );
+	will_return( __wrap_os_file_exists, IOT_TRUE );
+	result = app_path_which( out, 25u, NULL, "test_file" );
+	assert_int_equal( result, 15u );
+	assert_string_equal( out, "./test_file.exe");
+}
+
+static void test_app_path_which_out_path_only_paths( void **state )
+{
+	size_t result;
+	char out[ 25u ];
+
+#ifdef _WIN32
+	will_return( __wrap_os_env_get, "C:\\Windows;C:\\Windows\\System32" );
+#else
+	will_return( __wrap_os_env_get, "/usr/local:/usr/local/bin" );
+#endif
+	will_return( __wrap_os_env_get, "" );
+	will_return( __wrap_os_make_path, "./test_file" );
+	will_return( __wrap_os_file_exists, IOT_FALSE );
+#ifdef _WIN32
+	will_return( __wrap_os_make_path, "C:\\Windows\\test_file" );
+#else
+	will_return( __wrap_os_make_path, "/usr/local/test_file" );
+#endif
+	will_return( __wrap_os_file_exists, IOT_TRUE );
+	result = app_path_which( out, 25u, NULL, "test_file" );
+	assert_int_equal( result, 20u );
+#ifdef _WIN32
+	assert_string_equal( out, "C:\\Windows\\test_file");
+#else
+	assert_string_equal( out, "/usr/local/test_file");
+#endif
+}
+
+static void test_app_path_which_out_path_first_dir_env_vars( void **state )
+{
+	size_t result;
+	char out[ 25u ];
+
+#ifdef _WIN32
+	will_return( __wrap_os_env_get, "C:\\Windows;C:\\Windows\\System32" );
+	will_return( __wrap_os_env_get, ".bat;com;.exe" );
+#else
+	will_return( __wrap_os_env_get, "/usr/local:/usr/local/bin" );
+	will_return( __wrap_os_env_get, ".bat:com:.exe" );
+#endif
+	will_return( __wrap_os_make_path, "base_dir/test_file" );
+	will_return( __wrap_os_file_exists, IOT_FALSE );
+#ifdef _WIN32
+	will_return( __wrap_os_make_path, "C:\\Windows\\test_file.bat" );
+#else
+	will_return( __wrap_os_make_path, "/usr/local/test_file.bat" );
+#endif
+	will_return( __wrap_os_file_exists, IOT_TRUE );
+	result = app_path_which( out, 25u, "base_dir", "test_file" );
+	assert_int_equal( result, 24u );
+#ifdef _WIN32
+	assert_string_equal( out, "C:\\Windows\\test_file.bat" );
+#else
+	assert_string_equal( out, "/usr/local/test_file.bat" );
+#endif
+}
+
+/* main */
+int main( int argc, char* argv[] )
+{
+	int result;
+	const struct CMUnitTest tests[] =
+	{
+		cmocka_unit_test( test_app_path_make_absolute_cur_dir_buff_too_small ),
+		cmocka_unit_test( test_app_path_make_absolute_cur_dir_failed ),
+		cmocka_unit_test( test_app_path_make_absolute_cur_dir_valid_with_sep ),
+		cmocka_unit_test( test_app_path_make_absolute_cur_dir_valid_without_sep ),
+		cmocka_unit_test( test_app_path_make_absolute_null_path ),
+		cmocka_unit_test( test_app_path_make_absolute_pass_absolute_path ),
+		cmocka_unit_test( test_app_path_make_absolute_relative_buff_too_small ),
+		cmocka_unit_test( test_app_path_make_absolute_relative_failed ),
+		cmocka_unit_test( test_app_path_make_absolute_relative_valid_with_sep ),
+		cmocka_unit_test( test_app_path_make_absolute_relative_valid_without_sep ),
+		cmocka_unit_test( test_app_path_which_null_file ),
+		cmocka_unit_test( test_app_path_which_null_path_exists ),
+		cmocka_unit_test( test_app_path_which_null_path_no_env_vars ),
+		cmocka_unit_test( test_app_path_which_null_path_not_found ),
+		cmocka_unit_test( test_app_path_which_null_path_only_exts ),
+		cmocka_unit_test( test_app_path_which_null_path_only_paths ),
+		cmocka_unit_test( test_app_path_which_out_path_exists ),
+		cmocka_unit_test( test_app_path_which_out_path_no_env_vars ),
+		cmocka_unit_test( test_app_path_which_out_path_not_found ),
+		cmocka_unit_test( test_app_path_which_out_path_only_exts ),
+		cmocka_unit_test( test_app_path_which_out_path_only_paths ),
+		cmocka_unit_test( test_app_path_which_out_path_first_dir_env_vars ),
+	};
+	MOCK_SYSTEM_ENABLED = 1;
+	result = cmocka_run_group_tests( tests, NULL, NULL );
+	MOCK_SYSTEM_ENABLED = 0;
+	return result;
+}
+


### PR DESCRIPTION
This patch set contains fixes to mainly to the argument parsing utility.
Mainly, it includes fixes to the following areas:
1) adds the ability to specify for a configuration file to generate using iot-control
2) adds an iterator for iterating through command line arguments
3) updates the current routines argument parser to utilize new iterator routines which will allow for future support of defining the same argument multiple times
4) ports unit tests from the old repository code to the new code repository to ensure that the code continues to work as expected.