### PR TITLE
tr50: always use 3 digits for milliseconds

### DIFF
--- a/src/api/plugin/tr50/tr50.c
+++ b/src/api/plugin/tr50/tr50.c
@@ -2509,7 +2509,7 @@ char *tr50_strtime( iot_timestamp_t ts,
 		{
 			size_t out_req;
 			out_req = (size_t)os_snprintf( &out[out_len],
-				len - out_len, ".%u", (unsigned int)ts );
+				len - out_len, ".%03u", (unsigned int)ts );
 
 			if ( out_req < len - out_len )
 				out_len += out_req;


### PR DESCRIPTION
fixes: #103

When publishing a timestamp in a tr50 message, the milliseconds where
just being added as the number of milliseconds.  However, this was
misleading as on the cloud, as 1 or 2 digit milliseconds where missing
leading 0's.  For example, .57 was being represented instead of the
intended .057.  This causes the cloud to not show the events in the
correct order.

Signed-off-by: Keith Holman <keith.holman@windriver.com>