### PR TITLE
api: handle short device id's

### DIFF
--- a/src/api/iot_base.c
+++ b/src/api/iot_base.c
@@ -543,20 +543,24 @@ iot_status_t iot_base_device_id_set(
 			if ( fd  != OS_FILE_INVALID )
 			{
 				/* read uuid from the file */
+				size_t i = 0u;
 				device_id_len =
 					os_file_read( device_id, sizeof(char),
 						IOT_ID_MAX_LEN, fd );
 				os_file_close( fd );
-				if( device_id_len >= IOT_ID_MAX_LEN )
+				if ( device_id_len >= IOT_ID_MAX_LEN )
 					device_id_len = IOT_ID_MAX_LEN;
-				if ( device_id_len > 0u &&
-					device_id[device_id_len] == '\n' )
-					--device_id_len;
+				/* ensure device id only contains
+				 * "printable" characters */
+				while ( i < device_id_len &&
+					device_id[i] >= ' ' &&
+					device_id[i] <= '~')
+					++i;
+				device_id_len = i;
 				device_id[device_id_len] = '\0';
 				if ( device_id_len > 0u )
 					IOT_LOG( NULL, IOT_LOG_INFO,
-						"Device id: %s\n",
-						device_id );
+						"Device id: %s", device_id );
 			}
 
 			if ( device_id_len == 0u )

--- a/test/unit/mock/mock_osal.c
+++ b/test/unit/mock/mock_osal.c
@@ -24,6 +24,7 @@
 
 #include <os.h>
 #include <string.h>
+#include <test_support.h>
 
 /* mock definitions */
 void *__wrap_os_calloc( size_t nmemb, size_t size );
@@ -214,7 +215,10 @@ size_t __wrap_os_file_read( void *ptr, size_t size, size_t nmemb, os_file_t stre
 {
 	size_t result = mock_type( size_t );
 	if ( result != 0u )
+	{
 		result = size * nmemb;
+		test_generate_random_string( ptr, result );
+	}
 	return result;
 }
 


### PR DESCRIPTION
fixes: 113

Previously there was an error reading the device_id file containing an
id < 36 characters and containing a "new-line" character.   The MQTT
connections was using the new-line character as part of the client id,
causing the connection to not be accepted by the cloud.  This patch
fixes the reading to test if there are any valid ascii characters in the
device id file.

Signed-off-by: Keith Holman <keith.holman@windriver.com>