### PR TITLE
Build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
     packages:
       - cmake
       - libarchive-dev
+      - libcmocka-dev
       - libjansson-dev
       - libjson-c-dev
       - libcurl4-openssl-dev

--- a/build.sh
+++ b/build.sh
@@ -32,22 +32,6 @@ mkdir -p "$DEPS_DIR"
 mkdir -p "$DEPS_DIR/include"
 mkdir -p "$DEPS_DIR/lib"
 
-# cmocka
-wget https://cmocka.org/files/1.1/cmocka-1.1.1.tar.xz
-tar -xvf cmocka-1.1.1.tar.xz
-if [ -e cmocka-1.1.1 ]; then
-cd cmocka-1.1.1
-if [ ! -e cmake_build ]; then
-mkdir cmake_build
-fi
-cd cmake_build
-cmake -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX:PATH="$DEPS_DIR" ..
-make
-make install
-cd ../..
-rm -rf cmocka-1.1.1
-fi
-
 # jsmn
 git clone https://github.com/zserge/jsmn.git jsmn
 cd jsmn

--- a/src/api/json/iot_json_decode.c
+++ b/src/api/json/iot_json_decode.c
@@ -1137,7 +1137,7 @@ void iot_json_decode_terminate(
 #elif defined( IOT_JSON_JSONC )
 #else /* defined( IOT_JSON_JSMN ) */
 #ifndef IOT_STACK_ONLY
-		if ( decoder->flags & IOT_JSON_FLAG_DYNAMIC )
+		if ( decoder->flags & IOT_JSON_FLAG_DYNAMIC && decoder->tokens )
 			iot_json_free( decoder->tokens );
 #endif /* ifndef IOT_STACK_ONLY */
 #endif /* defined( IOT_JSON_JSMN ) */

--- a/test/test-support/test_support.h
+++ b/test/test-support/test_support.h
@@ -28,6 +28,120 @@
 
 #include <stdio.h> /* for snprintf */
 
+/* function not available in older cmocka versions */
+/* introduced in cmocka 1.1.1 */
+/* introduced in cmocka 1.1.0 */
+/* introduced in cmocka 1.0.1 */
+#if !defined(assert_ptr_equal)
+#define assert_ptr_equal(a,b) _assert_int_equal(\
+	cast_to_largest_integral_type(a), \
+	cast_to_largest_integral_type(b), __FILE__, __LINE__)
+#endif /* if !defined(assert_ptr_equal) */
+
+#if !defined(assert_ptr_not_equal)
+#define assert_ptr_not_equal(a,b) _assert_int_not_equal(\
+	cast_to_largest_integral_type(a), \
+	cast_to_largest_integral_type(b), __FILE__, __LINE__)
+#endif /* !defined(assert_ptr_not_equal) */
+
+/* introduced in cmocka 1.0.0 */
+#if !defined(test_realloc)
+void *_test_realloc(void *ptr,
+	const size_t size,
+	const char *file,
+	const int line);
+#define test_realloc(ptr,size) _test_realloc(ptr, size, __FILE__, __LINE__)
+#define NEED_TEST_REALLOC 1
+#endif /* if !defined(test_realloc) */
+
+#if !defined(cmocka_unit_test)
+#define CMUnitTestFunction UnitTestFunction
+typedef int (*CMFixtureFunction)(void **state);
+struct CMUnitTest
+{
+	const char *name;
+	CMUnitTestFunction test_func;
+	CMFixtureFunction setup_func;
+	CMFixtureFunction teardown_func;
+};
+#define cmocka_unit_test(f) {#f, f, NULL, NULL}
+#endif /* if !defined(cmocka_unit_test) */
+
+#if !defined(cmocka_unit_test_setup)
+#define cmocka_unit_test_setup(f, setup) {#f, f, setup, NULL}
+#endif /* if !defined(cmocka_unit_test_setup) */
+
+#if !defined(cmocka_unit_test_teardown)
+#define cmocka_unit_test_teardown(f, teardown) {#f, f, NULL, teardown}
+#endif /* if !defined(cmocka_unit_test_teardown) */
+
+#if !defined(cmocka_unit_test_setup_teardown)
+#define cmocka_unit_test_setup_teardown(f, setup, teardown) {#f, f, setup, teardown}
+#endif /* if !defined(cmocka_unit_test_setup_teardown) */
+
+#if !defined(cmocka_run_group_tests)
+int _cmocka_run_group_tests(const char *group_name,
+	const struct CMUnitTest *const tests,
+	const size_t num_tests,
+	CMFixtureFunction group_setup,
+	CMFixtureFunction group_teardown);
+#define cmocka_run_group_tests(group_tests, group_setup, group_teardown) \
+	_cmocka_run_group_tests(#group_tests, group_tests, \
+		sizeof(group_tests)/sizeof(group_tests)[0], \
+		group_setup, group_teardown)
+#define NEED_CMOCKA_RUN_GROUP_TESTS 1
+#endif /* if !defined(cmocka_run_group_tests) */
+
+#if !defined(cmocka_run_group_tests_name)
+#define cmocka_run_group_tests_name(group_name, group_tests, group_setup, \
+		group_teardown) \
+	_cmocka_run_group_tests(group_name, group_tests, \
+		sizeof(group_tests)/sizeof(group_tests)[0], \
+		group_setup, group_teardown)
+#endif /* if !defined(cmocka_run_group_tests_name) */
+
+/* introduced in cmocka 0.4.1 */
+/* introduced in cmocka 0.4.0 */
+#if !defined(assert_return_code)
+void _assert_return_code(const LargestIntegralType result,
+	size_t rlen,
+	const LargestIntegralType error,
+	const char * const expression,
+	const char * const file,
+	const int line);
+#define assert_return_code(rc, error) _assert_return_code(\
+	cast_to_largest_integral_type(a), sizeof(rc), \
+	cast_to_largest_integral_type(error), #rc, __FILE__, __LINE__)
+#define NEED_ASSERT_RETURN_CODE 1
+#endif /* if !defined(assert_return_code) */
+
+/* introduced in cmocka 0.3.2 */
+/* introduced in cmocka 0.3.1 */
+/* introduced in cmocka 0.3.0 */
+/* introduced in cmocka 0.2.0
+ * - assert_false
+ * - assert_in_range
+ * - assert_in_set
+ * - assert_int_equal
+ * - assert_int_not_equal
+ * - assert_memory_equal
+ * - assert_memory_not_equal
+ * - assert_non_null
+ * - assert_not_in_range
+ * - assert_not_in_set
+ * - assert_null **
+ * - assert_string_equal
+ * - assert_string_not_equal
+ * - assert_true
+ *
+ * - expect_assert_failure
+ * - mock_assert
+ *
+ * - test_calloc
+ * - test_malloc
+ * - test_free
+ */
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* ifdef __cplusplus */

--- a/test/unit/api/iot_action_test.c
+++ b/test/unit/api/iot_action_test.c
@@ -2081,7 +2081,8 @@ static void test_iot_action_parameter_set_raw_new_parameter( void **state )
 	for ( i = 0u; i < request.parameter_count; ++i )
 	{
 		os_free( request.parameter[i].name );
-		os_free( request.parameter[i].data.heap_storage );
+		if ( request.parameter[i].data.heap_storage )
+			os_free( request.parameter[i].data.heap_storage );
 	}
 	os_free( request.parameter );
 #endif
@@ -2213,7 +2214,8 @@ static void test_iot_action_parameter_set_raw_type_null( void **state )
 	for ( i = 0u; i < request.parameter_count; ++i )
 	{
 		os_free( request.parameter[i].name );
-		os_free( request.parameter[i].data.heap_storage );
+		if ( request.parameter[i].data.heap_storage )
+			os_free( request.parameter[i].data.heap_storage );
 	}
 	os_free( request.parameter );
 #endif
@@ -2306,7 +2308,8 @@ static void test_iot_action_parameter_set_raw_valid( void **state )
 	for ( i = 0u; i < request.parameter_count; ++i )
 	{
 		os_free( request.parameter[i].name );
-		os_free( request.parameter[i].data.heap_storage );
+		if ( request.parameter[i].data.heap_storage )
+			os_free( request.parameter[i].data.heap_storage );
 	}
 	os_free( request.parameter );
 #endif
@@ -4822,9 +4825,11 @@ static void test_iot_action_process_wait_queue_full( void **state )
 	/* clean up */
 #ifndef IOT_STACK_ONLY
 	for ( i = 0u; i < IOT_ACTION_STACK_MAX; ++i )
-		os_free( lib.action[i].name );
+		if ( lib.action[i].name )
+			os_free( lib.action[i].name );
 	for ( i = 0u; i < IOT_ACTION_QUEUE_MAX; ++i )
-		os_free( lib.request_queue[i].name );
+		if ( lib.request_queue[i].name )
+			os_free( lib.request_queue[i].name );
 #endif
 }
 
@@ -5487,7 +5492,10 @@ static void test_iot_action_request_option_set_raw_valid( void **state )
 	assert_int_equal( req.option[0u].data.has_value, IOT_TRUE );
 	assert_int_equal( req.option[0u].data.type, IOT_TYPE_RAW );
 	assert_int_equal( req.option[0u].data.value.raw.length, 5u );
-	assert_string_equal( req.option[0u].data.value.raw.ptr, (const char*)"test" );
+	assert_string_equal( req.option[0u].data.value.raw.ptr,
+		(const char*)"test" );
+	assert_ptr_equal( req.option[0u].data.value.raw.ptr,
+		req.option[0u].data.heap_storage );
 #endif
 
 	/* clean up */

--- a/test/unit/api/iot_base_test.c
+++ b/test/unit/api/iot_base_test.c
@@ -1106,10 +1106,10 @@ static void test_iot_config_set_raw_overwrite_data( void **state )
 	assert_int_equal( lib.options_config->option[0].data.type, IOT_TYPE_RAW );
 	assert_non_null( lib.options_config->option[0].data.value.raw.ptr );
 	assert_int_equal( lib.options_config->option[0].data.has_value, IOT_TRUE );
-#endif
 
 	/* clean up */
 	os_free( opt.data.heap_storage );
+#endif
 }
 
 static void test_iot_config_set_raw_overwrite_null( void **state )

--- a/test/unit/api/iot_common_test.c
+++ b/test/unit/api/iot_common_test.c
@@ -349,7 +349,6 @@ static void test_iot_common_arg_get_bool_from_string_null( void **state )
 	result = iot_common_arg_get_wrapper( &obj, IOT_TRUE, IOT_TYPE_BOOL, &data );
 	assert_int_equal( result, IOT_STATUS_SUCCESS );
 	assert_int_equal( data, IOT_FALSE );
-	os_free( obj.heap_storage );
 }
 
 static void test_iot_common_arg_get_bool_from_string_true( void **state )
@@ -2892,10 +2891,11 @@ static void test_iot_common_data_copy_location( void **state )
 	assert_int_equal( to.value.location->source, source );
 	assert_memory_equal( &to.value.location->speed, &speed, sizeof( iot_float64_t ) );
 	assert_string_equal( to.value.location->tag, tag );
-#endif
 
 	/* clean up */
 	os_free( to.heap_storage );
+#endif
+
 	test_free( from.value.location->tag );
 	test_free( from.heap_storage );
 }

--- a/test/unit/mock/mock_osal.c
+++ b/test/unit/mock/mock_osal.c
@@ -234,6 +234,13 @@ os_bool_t __wrap_os_flush( os_file_t stream )
 
 void __wrap_os_free( void *ptr )
 {
+	/* in cmocka 0.3.2, test_free( NULL ) will generate an error.  So let's
+	 * ensure that ptr is valid, in case use is using a new version of
+	 * cmocka they will also see this error.  Although, according to the
+	 * man pages of "free", passing NULL is valid. But we never know if all
+	 * operating systems behave 100% correctly so it is a good idea to
+	 * explicitly check. */
+	assert_non_null( ptr );
 	test_free( ptr );
 }
 


### PR DESCRIPTION
This includes 2 patches...

1) Add declarations to the test-support library to allow unit tests written for: cmocka 1.0 tests to run under cmocka 0.3.2...  (this is because travis running Ubuntu 14.04, can install cmocka 0.3.2 as a package.  reducing the need to build it for every use)

2) It updates the build.sh script to only build the dependent packages that it requires.  This allows the automated builds to be slightly faster.