### PR TITLE
device-manager: 'remote-access-support' cfg support

### DIFF
--- a/src/device-manager/device_manager_main.h
+++ b/src/device-manager/device_manager_main.h
@@ -20,6 +20,7 @@
 
 #include "os.h"
 #include "device_manager_file.h"
+#include "iot_json.h"                 /* for json */
 #include <iot.h>
 
 /**
@@ -103,7 +104,7 @@ struct device_manager_info
 	/** @brief run time directory */
 	char runtime_dir[PATH_MAX + 1u];
 	/** @brief valid remote login protocols */
-	char remote_login_protocols[REMOTE_LOGIN_PROTOCOL_MAX];
+	iot_json_encoder_t* remote_login_protocols;
 	/** @brief number of loops main loop has gone through */
 	size_t loop_count;
 	/** @brief log level */

--- a/src/device-manager/iot.cfg.example
+++ b/src/device-manager/iot.cfg.example
@@ -12,6 +12,12 @@
 		"dump_log_files": True,
 		"remote_login" : True 
 	},
-	"upload_remove_on_success": True
+	"upload_remove_on_success": True,
+	"remote_access_support":[
+		{ "name": "Telnet", "port":"23", "session_timeout":"120" },
+		{ "name": "SSH",    "port":"22", "session_timeout":"120" },
+		{ "name": "VNC",    "port":"5900" },
+		{ "name": "HTTP",   "port":"80" }
+	]
 }
 


### PR DESCRIPTION
Resolves: #120  

This patch adds support for publishing the
remote_access_support attribute from the config file
to the cloud, in the form of a JSON string.
Also checks that the ports specified are active
before publishing.