### PR TITLE
build: exit on build error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,6 +23,9 @@
 #  $ ./build.sh
 # --------------------------------------------------------------------
 
+# exit on error
+set -e
+
 # Required system dependencies:
 #    See README.md for list of dependencies from the build host
 #


### PR DESCRIPTION
fixes: #105 

This patch updates the build script to exit on any critical  error.
This helps us to diagnose why/where exactly where the script fails.