### PR TITLE
api: Add mutex lock for action completion operation

### DIFF
--- a/src/api/iot_action.c
+++ b/src/api/iot_action.c
@@ -1316,9 +1316,19 @@ iot_status_t iot_action_process(
 			/* send command execution result to the cloud */
 			iot_action_request_set_status( request,
 				action_result, NULL );
+
+#ifdef IOT_THREAD_SUPPORT
+		if ( !( lib->flags & IOT_FLAG_SINGLE_THREAD ) )
+			os_thread_mutex_lock( &lib->worker_mutex );
+#endif /* ifdef IOT_THREAD_SUPPORT */
 			result = iot_plugin_perform( lib, NULL, &max_time_out,
 				IOT_OPERATION_ACTION_COMPLETE, action, request,
 				NULL );
+
+#ifdef IOT_THREAD_SUPPORT
+		if ( !( lib->flags & IOT_FLAG_SINGLE_THREAD ) )
+			os_thread_mutex_unlock( &lib->worker_mutex );
+#endif /* ifdef IOT_THREAD_SUPPORT */
 
 			/* free memory associated with the request */
 			iot_action_request_free( request );

--- a/src/api/plugin/tr50/tr50.c
+++ b/src/api/plugin/tr50/tr50.c
@@ -2140,13 +2140,6 @@ void tr50_on_message(
 								const size_t msg_count =
 									iot_json_decode_array_size( json, j_messages );
 
-								/* check mailbox for more actions if queue is available */
-								if ( data->lib->request_queue_free_count + 1
-										< IOT_ACTION_QUEUE_MAX )
-									if( iot_timestamp_now() - data->time_last_mailbox_check
-											> TR50_MAILBOX_CHECK_INTERVAL )
-										tr50_check_mailbox( data, NULL );
-
 								for ( i = 0u; i < msg_count; ++i )
 								{
 									const iot_json_item_t *j_cmd_item;
@@ -2187,6 +2180,14 @@ void tr50_on_message(
 												os_snprintf( name, IOT_NAME_MAX_LEN, "%.*s", (int)v_len, v );
 												name[ IOT_NAME_MAX_LEN ] = '\0';
 												req = iot_action_request_allocate( data->lib, name, "tr50" );
+
+												/* check mailbox for more actions if queue is available */
+												if ( data->lib->request_queue_free_count
+														< IOT_ACTION_QUEUE_MAX )
+													if( iot_timestamp_now() - data->time_last_mailbox_check
+															> TR50_MAILBOX_CHECK_INTERVAL )
+														tr50_check_mailbox( data, NULL );
+
 												if ( req )
 													iot_action_request_option_set( req, "id", IOT_TYPE_STRING, id );
 												else


### PR DESCRIPTION
This adds a mutex lock around the performing of the action complete operation
of a plugin, as part of the mailbox protocol changes.

Previously it was possible for a race condition to occur when
two actions completed at exactly the same time, causing an invalid
double check.

This patch also changes the mailbox check on received method requests
to only occur after the received request is already allocated. This change,
along with the lock around the action complete operation should prevent
the "maximum inbound requests reached" message from appearing.