### PR TITLE
build: fix for android build

### DIFF
--- a/src/device-manager/device_manager_main.c
+++ b/src/device-manager/device_manager_main.c
@@ -1663,8 +1663,8 @@ iot_status_t device_manager_run_os_command( const char *cmd,
 				out_len[i] = 0u;
 			}
 		}
-		if ( os_system_run_wait( cmd, &retval, out_buf,
-			out_len, 0u ) == IOT_STATUS_SUCCESS &&
+		if ( os_system_run_wait( cmd, &retval, OS_TRUE, 0, 0u,
+			out_buf, out_len, 0u ) == IOT_STATUS_SUCCESS &&
 			     retval >= 0 )
 			result = IOT_STATUS_SUCCESS;
 		else


### PR DESCRIPTION
A recent change in the OSAL layer is causing the Android build to fail
due to mismatch of parameters.  This patch fixes the parameters to
match.

Signed-off-by: Keith Holman <keith.holman@windriver.com>