### PR TITLE
api: add conversion from string to raw

### DIFF
--- a/src/api/iot_action.c
+++ b/src/api/iot_action.c
@@ -602,7 +602,7 @@ iot_status_t iot_action_execute_command(
 						if ( space_left > min_size )
 						{
 							iot_base64_encode(
-								(uint8_t*)param_pos,
+								param_pos,
 								space_left,
 								(const uint8_t*)p->data.value.raw.ptr,
 								p->data.value.raw.length );

--- a/src/api/iot_base64.c
+++ b/src/api/iot_base64.c
@@ -2,7 +2,7 @@
  * @file
  * @brief Contains implementations for handling base64 data
  *
- * @copyright Copyright (C) 2017 Wind River Systems, Inc. All Rights Reserved.
+ * @copyright Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
  *
  * @license Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,9 @@ static const char base64_list[] =
  *
  * @returns -1 on error (illegal character) or the number of bytes decoded
  */
-IOT_SECTION ssize_t iot_base64_decode_block( unsigned char out[3], const unsigned char in[4] );
+IOT_SECTION static ssize_t iot_base64_decode_block(
+	uint8_t out[3],
+	const char in[4] );
 
 /**
  * @brief Encodes one block of data in base64
@@ -92,9 +94,16 @@ IOT_SECTION ssize_t iot_base64_decode_block( unsigned char out[3], const unsigne
  * @param[in]      in                  data to encode
  * @param[in]      len                 length of input data
  */
-IOT_SECTION static void iot_base64_encode_block( uint8_t out[4], const uint8_t in[3], size_t len );
+IOT_SECTION static void iot_base64_encode_block(
+	char out[4],
+	const uint8_t in[3],
+	size_t len );
 
-ssize_t iot_base64_decode( uint8_t *out, size_t out_len, const uint8_t *in, size_t in_len )
+ssize_t iot_base64_decode(
+	uint8_t *out,
+	size_t out_len,
+	const char *in,
+	size_t in_len )
 {
 	ssize_t num_bytes = -1;
 	if ( out && in )
@@ -105,7 +114,8 @@ ssize_t iot_base64_decode( uint8_t *out, size_t out_len, const uint8_t *in, size
 		while ( i < in_len && out_len > 0u && num_bytes >= 0 )
 		{
 			unsigned char out_temp[3];
-			ssize_t out_chars = iot_base64_decode_block( out_temp, (const unsigned char *)in );
+			ssize_t out_chars = iot_base64_decode_block(
+				out_temp, in );
 			if ( out_chars < 1 || out_chars > 3 )
 				num_bytes = -1;
 			else if ( out_chars > 0 && out_chars <= 3 )
@@ -126,7 +136,9 @@ ssize_t iot_base64_decode( uint8_t *out, size_t out_len, const uint8_t *in, size
 	return num_bytes;
 }
 
-ssize_t iot_base64_decode_block( unsigned char out[3], const unsigned char in[4] )
+ssize_t iot_base64_decode_block(
+	uint8_t out[3],
+	const char in[4] )
 {
 	ssize_t i, num_bytes = 3;
 	char tmp[4];
@@ -154,7 +166,8 @@ ssize_t iot_base64_decode_block( unsigned char out[3], const unsigned char in[4]
 	return num_bytes;
 }
 
-size_t iot_base64_decode_size( size_t in_bytes )
+size_t iot_base64_decode_size(
+	size_t in_bytes )
 {
 	size_t result = 0u;
 	if ( in_bytes > 0u )
@@ -162,7 +175,11 @@ size_t iot_base64_decode_size( size_t in_bytes )
 	return result;
 }
 
-size_t iot_base64_encode( uint8_t *out, size_t out_len, const uint8_t *in, size_t in_len )
+size_t iot_base64_encode(
+	char *out,
+	size_t out_len,
+	const uint8_t *in,
+	size_t in_len )
 {
 	size_t result = 0u;
 	if ( out && out_len > 0u )
@@ -186,25 +203,29 @@ size_t iot_base64_encode( uint8_t *out, size_t out_len, const uint8_t *in, size_
 	return result;
 }
 
-void iot_base64_encode_block( uint8_t out[4], const uint8_t in[3], size_t len )
+void iot_base64_encode_block(
+	char out[4],
+	const uint8_t in[3],
+	size_t len )
 {
-	out[0] = (uint8_t)base64_list[in[0] >> 2];
-	out[1] = (uint8_t)base64_list[( in[0] & 0x03 ) << 4];
+	out[0] = base64_list[in[0] >> 2];
+	out[1] = base64_list[( in[0] & 0x03 ) << 4];
 	out[2] = '=';
 	out[3] = '=';
 	if ( len > 1u )
 	{
-		out[1] = (uint8_t)base64_list[( ( in[0] & 0x03 ) << 4 ) | ( ( in[1] & 0xf0 ) >> 4 )];
-		out[2] = (uint8_t)base64_list[( in[1] & 0x0f ) << 2];
+		out[1] = base64_list[( ( in[0] & 0x03 ) << 4 ) | ( ( in[1] & 0xf0 ) >> 4 )];
+		out[2] = base64_list[( in[1] & 0x0f ) << 2];
 		if ( len > 2u )
 		{
-			out[2] = (uint8_t)base64_list[( ( in[1] & 0x0f ) << 2 ) | ( ( in[2] & 0xc0 ) >> 6 )];
-			out[3] = (uint8_t)base64_list[in[2] & 0x3f];
+			out[2] = base64_list[( ( in[1] & 0x0f ) << 2 ) | ( ( in[2] & 0xc0 ) >> 6 )];
+			out[3] = base64_list[in[2] & 0x3f];
 		}
 	}
 }
 
-size_t iot_base64_encode_size( size_t in_bytes )
+size_t iot_base64_encode_size(
+	size_t in_bytes )
 {
 	size_t result = 0u;
 	if ( in_bytes > 0u )

--- a/src/api/plugin/tr50/tr50.c
+++ b/src/api/plugin/tr50/tr50.c
@@ -924,7 +924,7 @@ void tr50_append_value_raw(
 		heap = os_malloc( sizeof(uint8_t) * req_len + 1u );
 		if ( heap )
 		{
-			iot_base64_encode( heap, req_len, value, len );
+			iot_base64_encode( (char*)heap, req_len, value, len );
 			heap[req_len] = '\0';
 			value = heap;
 		}

--- a/src/api/shared/iot_base64.h
+++ b/src/api/shared/iot_base64.h
@@ -2,7 +2,7 @@
  * @file
  * @brief Contains definitions for handling base64 data
  *
- * @copyright Copyright (C) 2017 Wind River Systems, Inc. All Rights Reserved.
+ * @copyright Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
  *
  * @license Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,16 +32,16 @@ extern "C" {
  * result in the memory area pointed to by \c out. The result will \e not be
  * null-terminated.
  *
- * @param[out]     out                 pointer to destination
+ * @param[out]     out                 pointer to destination (as raw data)
  * @param[out]     out_len             size of destination buffer
- * @param[in]      in                  pointer to source
+ * @param[in]      in                  pointer to source in base64
  * @param[in]      in_len              length of source data
  *
  * @returns -1 on error (illegal character) or the number of bytes decoded
  */
 IOT_API IOT_SECTION ssize_t iot_base64_decode( uint8_t *out,
                                                size_t out_len,
-                                               const uint8_t *in,
+                                               const char *in,
                                                size_t in_len );
 
 /**
@@ -63,14 +63,14 @@ IOT_API IOT_SECTION size_t iot_base64_decode_size( size_t in_bytes );
  * result in the memory area pointed to by \c out. The result will \e not be
  * null-terminated.
  *
- * @param[out]     out                 pointer to destination
+ * @param[out]     out                 pointer to destination (stored as base64)
  * @param[out]     out_len             size of destination buffer
- * @param[in]      in                  pointer to source
+ * @param[in]      in                  pointer to raw data
  * @param[in]      in_len              length of source data
  *
  * @return Number of characters outputted
  */
-IOT_API IOT_SECTION size_t iot_base64_encode( uint8_t *out,
+IOT_API IOT_SECTION size_t iot_base64_encode( char *out,
                                               size_t out_len,
                                               const uint8_t *in,
                                               size_t in_len );

--- a/test/unit/api/CMakeLists.txt
+++ b/test/unit/api/CMakeLists.txt
@@ -45,7 +45,7 @@ list( REMOVE_ITEM MOCK_API_PART
 set( TEST_IOT_ACTION_MOCK ${MOCK_API_PART} ${MOCK_OSAL_FUNC} )
 set( TEST_IOT_ACTION_SRCS ${MOCK_API_SRCS} ${MOCK_OSAL_SRCS} "iot_action_test.c" )
 set( TEST_IOT_ACTION_LIBS ${MOCK_API_LIBS} ${MOCK_OSAL_LIBS} )
-set( TEST_IOT_ACTION_UNIT "iot_action.c" "iot_common.c" )
+set( TEST_IOT_ACTION_UNIT "iot_action.c" "iot_base64.c" "iot_common.c" )
 
 # iot_alarm.c
 set( MOCK_API_PART ${MOCK_API_FUNC} )
@@ -72,7 +72,7 @@ list( REMOVE_ITEM MOCK_API_PART
 set( TEST_IOT_BASE_MOCK ${MOCK_API_PART} ${MOCK_OSAL_FUNC} )
 set( TEST_IOT_BASE_SRCS ${MOCK_API_SRCS} ${MOCK_OSAL_SRCS} "iot_base_test.c" )
 set( TEST_IOT_BASE_LIBS ${MOCK_API_LIBS} ${MOCK_OSAL_LIBS} )
-set( TEST_IOT_BASE_UNIT "iot_base.c" "iot_common.c" "iot_option.c" )
+set( TEST_IOT_BASE_UNIT "iot_base.c" "iot_base64.c" "iot_common.c" "iot_option.c" )
 
 # iot_base64.c
 set( TEST_IOT_BASE64_MOCK )
@@ -84,7 +84,7 @@ set( TEST_IOT_BASE64_UNIT "iot_base64.c" )
 set( TEST_IOT_COMMON_MOCK ${MOCK_API_FUNC} ${MOCK_OSAL_FUNC} )
 set( TEST_IOT_COMMON_SRCS ${MOCK_API_SRCS} ${MOCK_OSAL_SRCS} "iot_common_test.c" )
 set( TEST_IOT_COMMON_LIBS ${MOCK_API_LIBS} ${MOCK_OSAL_LIBS} )
-set( TEST_IOT_COMMON_UNIT "iot_common.c" )
+set( TEST_IOT_COMMON_UNIT "iot_common.c" "iot_base64.c" )
 
 # json/iot_json_decode.c
 set( MOCK_API_PART ${MOCK_API_FUNC} )
@@ -153,7 +153,7 @@ list( REMOVE_ITEM MOCK_API_PART
 set( TEST_IOT_TELEMETRY_MOCK ${MOCK_API_PART} ${MOCK_OSAL_FUNC} )
 set( TEST_IOT_TELEMETRY_SRCS ${MOCK_API_SRCS} ${MOCK_OSAL_SRCS} "iot_telemetry_test.c" )
 set( TEST_IOT_TELEMETRY_LIBS ${MOCK_API_LIBS} ${MOCK_OSAL_LIBS} )
-set( TEST_IOT_TELEMETRY_UNIT "iot_telemetry.c" "iot_common.c" )
+set( TEST_IOT_TELEMETRY_UNIT "iot_telemetry.c" "iot_base64.c" "iot_common.c" )
 
 include( TestSupport )
 add_tests( ${TARGET} ${TESTS} )

--- a/test/unit/api/iot_base64_test.c
+++ b/test/unit/api/iot_base64_test.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * @brief unit testing for IoT library (base source file)
+ * @brief unit testing for base64 routines
  *
  * @copyright Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
  *
@@ -44,7 +44,8 @@ static void test_iot_base64_decode_bad_string( void **state )
 	assert_non_null( test_out );
 	memset( test_out, 0, out_length + 1 );
 
-	result = iot_base64_decode( test_out, out_length, (const uint8_t *)test_in, strlen( test_in ) );
+	result = iot_base64_decode( test_out, out_length,
+		test_in, strlen( test_in ) );
 	assert_int_equal( result, -1 );
 	assert_string_equal( test_out, "" );
 
@@ -75,7 +76,8 @@ static void test_iot_base64_decode_in_null( void **state )
 	assert_non_null( test_out );
 	memset( test_out, 0, out_length + 1 );
 
-	result = iot_base64_decode( test_out, out_length, NULL, strlen( test_in ) );
+	result = iot_base64_decode( test_out, out_length,
+		NULL, strlen( test_in ) );
 	assert_int_equal( result, -1 );
 	assert_string_equal( test_out, "" );
 
@@ -100,7 +102,8 @@ static void test_iot_base64_decode_invalid_char( void **state )
 	assert_non_null( test_out );
 	memset( test_out, 0, out_length + 1 );
 
-	result = iot_base64_decode( test_out, out_length, (const uint8_t *)test_in, strlen( test_in ) );
+	result = iot_base64_decode( test_out, out_length,
+		test_in, strlen( test_in ) );
 	assert_int_equal( result, -1 );
 	assert_string_equal( test_out, "" );
 
@@ -131,7 +134,8 @@ static void test_iot_base64_decode_out_3X_length( void **state )
 	assert_non_null( test_out );
 	memset( test_out, 0, out_length + 1 );
 
-	result = iot_base64_decode( test_out, out_length, (const uint8_t *)test_in, strlen( test_in ) );
+	result = iot_base64_decode( test_out, out_length,
+		test_in, strlen( test_in ) );
 	assert_int_equal( result, strlen( expect_out ) );
 	assert_string_equal( test_out, expect_out );
 
@@ -162,7 +166,8 @@ static void test_iot_base64_decode_out_3Xplus2_length( void **state )
 	assert_non_null( test_out );
 	memset( test_out, 0, out_length + 1 );
 
-	result = iot_base64_decode( test_out, out_length, (const uint8_t *)test_in, strlen( test_in ) );
+	result = iot_base64_decode( test_out, out_length,
+		test_in, strlen( test_in ) );
 	assert_int_equal( result, strlen( expect_out ) );
 	assert_string_equal( test_out, expect_out );
 
@@ -219,14 +224,15 @@ static void test_iot_base64_encode( void **state )
 	    "vehemence of any carnal pleasure.";
 	size_t result;
 	size_t out_length;
-	uint8_t *test_out;
+	char *test_out;
 
 	out_length = strlen( expect_out );
 	test_out = malloc( out_length + 1 );
 	assert_non_null( test_out );
 	memset( test_out, 0, out_length + 1 );
 
-	result = iot_base64_encode( test_out, out_length, (const uint8_t *)test_in, strlen( test_in ) );
+	result = iot_base64_encode( test_out, out_length,
+		(const uint8_t *)test_in, strlen( test_in ) );
 	assert_int_equal( result, out_length );
 	assert_string_equal( test_out, expect_out );
 
@@ -250,14 +256,15 @@ static void test_iot_base64_encode_in_zero_length( void **state )
 	    "vehemence of any carnal pleasure.";
 	size_t result;
 	size_t out_length;
-	uint8_t *test_out;
+	char *test_out;
 
 	out_length = strlen( expect_out );
 	test_out = malloc( out_length + 1 );
 	assert_non_null( test_out );
 	memset( test_out, 0, out_length + 1 );
 
-	result = iot_base64_encode( test_out, out_length, (const uint8_t *)test_in, 0 );
+	result = iot_base64_encode( test_out, out_length,
+		(const uint8_t *)test_in, 0 );
 	assert_int_equal( result, 0 );
 	assert_string_equal( test_out, "" );
 
@@ -281,14 +288,15 @@ static void test_iot_base64_encode_in_null( void **state )
 	    "vehemence of any carnal pleasure.";
 	size_t result;
 	size_t out_length;
-	uint8_t *test_out;
+	char *test_out;
 
 	out_length = strlen( expect_out );
 	test_out = malloc( out_length + 1 );
 	assert_non_null( test_out );
 	memset( test_out, 0, out_length + 1 );
 
-	result = iot_base64_encode( test_out, out_length, NULL, strlen( test_in ) );
+	result = iot_base64_encode( test_out, out_length,
+		NULL, strlen( test_in ) );
 	assert_int_equal( result, 0 );
 	assert_string_equal( test_out, "" );
 
@@ -312,14 +320,15 @@ static void test_iot_base64_encode_out_zero_length( void **state )
 	    "vehemence of any carnal pleasure.";
 	size_t result;
 	size_t out_length;
-	uint8_t *test_out;
+	char *test_out;
 
 	out_length = strlen( expect_out );
 	test_out = malloc( out_length + 1 );
 	assert_non_null( test_out );
 	memset( test_out, 0, out_length + 1 );
 
-	result = iot_base64_encode( test_out, 0, (const uint8_t *)test_in, strlen( test_in ) );
+	result = iot_base64_encode( test_out, 0,
+		(const uint8_t *)test_in, strlen( test_in ) );
 	assert_int_equal( result, 0 );
 	assert_string_equal( test_out, "" );
 


### PR DESCRIPTION
fixes: #114

This patch adds a basic conversion from string to raw type inside the
library.  This this noticed when incoming parameters are registered as
"raw types" but are sent in base64 string values from the cloud.  This
allows for the internal conversion from base64 strings to raw data.

Signed-off-by: Keith Holman <keith.holman@windriver.com>