### PR TITLE
system_run: use updated os_system_run signature

### DIFF
--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 Wind River Systems, Inc. All Rights Reserved.
+# Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,13 +67,15 @@ add_library( "${IOT_LIBRARY_NAME}"
 	${API_SRCS_C}
 )
 
-target_link_libraries( "${IOT_LIBRARY_NAME}" "dl" "m"
+target_link_libraries( "${IOT_LIBRARY_NAME}"
 	${CMAKE_THREAD_LIBS_INIT}
 	${JSON_LIBRARIES}
 	${MQTT_LIBRARIES}
 	${OSAL_LIBRARIES}
 	${PLUGIN_BUILTIN_LIBS}
 	${LibArchive_LIBRARIES}
+	${CMAKE_THREAD_LIBS_INIT}
+	${CMAKE_DL_LIBS} "m"
 )
 
 set_target_properties( "${IOT_LIBRARY_NAME}" PROPERTIES

--- a/src/control/CMakeLists.txt
+++ b/src/control/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 Wind River Systems, Inc. All Rights Reserved.
+# Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -7,9 +7,9 @@
 #
 #    http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software  distributed
-# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
-# OR CONDITIONS OF ANY KIND, either express or implied.
+# Unless required by applicable law or agreed to in writing, softwarei
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #
 
 set( TARGET "iot-control" )
@@ -62,7 +62,7 @@ add_executable( "${TARGET}"
 )
 
 target_link_libraries( "${TARGET}"
-	iot
+	${IOT_LIBRARY_NAME}
 	iotutils
 )
 

--- a/src/device-manager/CMakeLists.txt
+++ b/src/device-manager/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 Wind River Systems, Inc. All Rights Reserved.
+# Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -63,12 +63,8 @@ add_executable( ${TARGET}
 
 # Required libraries
 target_link_libraries( ${TARGET}
+	${IOT_LIBRARY_NAME}
 	iotutils
-	iot
-	${JSMN_LIBRARIES}
-	${OSAL_LIBRARIES}
-	${CMAKE_THREAD_LIBS_INIT}
-	dl
 )
 
 # Installation instructions

--- a/src/device-manager/device_manager_ota.c
+++ b/src/device-manager/device_manager_ota.c
@@ -1,8 +1,8 @@
 /**
  * @file
- * @brief Source file for service handling in the IoT control application
+ * @brief Source file for OTA support in the device-manager application
  *
- * @copyright Copyright (C) 2017 Wind River Systems, Inc. All Rights Reserved.
+ * @copyright Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
  *
  * @license Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -396,7 +396,7 @@ iot_status_t device_manager_ota_install_execute(
 				"software update package_path: %s, file_name: %s",
 				package_path,
 				file_name);
-		if ( result ==IOT_STATUS_SUCCESS )
+		if ( result == IOT_STATUS_SUCCESS )
 		{
 			char update_path[PATH_MAX + 1u];
 			char exec_dir[PATH_MAX + 1u];
@@ -461,24 +461,23 @@ iot_status_t device_manager_ota_install_execute(
 
 		if ( command_with_params[0] != '\0' )
 		{
-			char buf[1u] = "\0";
-			char *out_buf[2u] = { buf, buf };
-			size_t out_len[2u] = { 1u, 1u };
-			int system_ret = 1;
+			os_system_run_args_t args = OS_SYSTEM_RUN_ARGS_INIT;
 
 			IOT_LOG( iot_lib, IOT_LOG_TRACE,
 				"Executing command: %s", command_with_params );
 
-			result = IOT_STATUS_SUCCESS;
-			os_system_run_wait( command_with_params,
-				&system_ret, OS_FALSE, 0, 0u,
-				out_buf, out_len, 0U );
+			result = IOT_STATUS_EXECUTION_ERROR;
+
+			args.cmd = command_with_params;
+			args.block = OS_TRUE;
+			if ( os_system_run( &args ) == OS_STATUS_SUCCESS )
+				result = IOT_STATUS_SUCCESS;
 
 			IOT_LOG( iot_lib, IOT_LOG_TRACE,
 				"Completed executing OTA script with result: %i",
-				system_ret );
+				args.return_code );
 
-			if ( system_ret != 0 )
+			if ( args.return_code != 0 )
 				result = IOT_STATUS_EXECUTION_ERROR;
 		}
 

--- a/src/relay/CMakeLists.txt
+++ b/src/relay/CMakeLists.txt
@@ -57,7 +57,7 @@ target_link_libraries( ${TARGET}
 	${OPENSSL_LIBRARIES}
 	${OSAL_LIBRARIES}
 	${CMAKE_THREAD_LIBS_INIT}
-	dl
+	${CMAKE_DL_LIBS} "m"
 )
 
 # Installation instructions

--- a/src/update/CMakeLists.txt
+++ b/src/update/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 Wind River Systems, Inc. All Rights Reserved.
+# Copyright (C) 2017-2018 Wind River Systems, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ add_executable( ${TARGET}
 )
 
 target_link_libraries( ${TARGET}
-	iot
+	${IOT_LIBRARY_NAME}
 	iotutils
 )
 

--- a/test/unit/api/iot_action_test.c
+++ b/test/unit/api/iot_action_test.c
@@ -2493,10 +2493,11 @@ static void test_iot_action_process_command_no_return( void **state )
 	lib.request_queue_wait[0]->name = os_malloc( IOT_NAME_MAX_LEN + 1u );
 #endif
 	strncpy( lib.request_queue_wait[0]->name, "action name", IOT_NAME_MAX_LEN );
-	expect_string( __wrap_os_system_run_wait, command, "script_path" );
-	will_return( __wrap_os_system_run_wait, 0u ); /* IOT_STATUS_INVOKED ); */
-	will_return( __wrap_os_system_run_wait, IOT_STATUS_INVOKED );
-	/*will_return( __wrap_os_system_run_wait, IOT_STATUS_INVOKED );*/
+	expect_string( __wrap_os_system_run, args->cmd, "script_path" );
+	will_return( __wrap_os_system_run, 0u );
+	will_return( __wrap_os_system_run, NULL ); /* stdout */
+	will_return( __wrap_os_system_run, NULL ); /* stderr */
+	will_return( __wrap_os_system_run, IOT_STATUS_INVOKED );
 	will_return( __wrap_iot_plugin_perform, IOT_STATUS_SUCCESS );
 	result = iot_action_process( &lib, 0u );
 	assert_int_equal( result, IOT_STATUS_SUCCESS );
@@ -2583,11 +2584,11 @@ static void test_iot_action_process_command_parameter_bool( void **state )
 	lib.request_queue_wait[0]->parameter[0].data.type = IOT_TYPE_BOOL;
 	lib.request_queue_wait[0]->parameter[0].data.value.boolean = IOT_TRUE;
 	lib.request_queue_wait[0]->parameter[0].data.has_value = IOT_TRUE;
-	expect_string( __wrap_os_system_run_wait, command, "script_path --bool=1" );
-	will_return( __wrap_os_system_run_wait, 0u );
-	will_return( __wrap_os_system_run_wait, "this is stdout" );
-	will_return( __wrap_os_system_run_wait, "this is stderr" );
-	will_return( __wrap_os_system_run_wait, IOT_STATUS_SUCCESS );
+	expect_string( __wrap_os_system_run, args->cmd, "script_path --bool=1" );
+	will_return( __wrap_os_system_run, 0u );
+	will_return( __wrap_os_system_run, "this is stdout" );
+	will_return( __wrap_os_system_run, "this is stderr" );
+	will_return( __wrap_os_system_run, IOT_STATUS_SUCCESS );
 #ifndef IOT_STACK_ONLY
 	/* add parameter: retval */
 	will_return( __wrap_os_realloc, 1 ); /* increase parameter array */
@@ -2702,12 +2703,12 @@ static void test_iot_action_process_command_parameter_float( void **state )
 	lib.request_queue_wait[0]->parameter[1].data.type = IOT_TYPE_FLOAT64;
 	lib.request_queue_wait[0]->parameter[1].data.value.float64 = 64.64;
 	lib.request_queue_wait[0]->parameter[1].data.has_value = IOT_TRUE;
-	expect_string( __wrap_os_system_run_wait, command,
+	expect_string( __wrap_os_system_run, args->cmd,
 		"script_path --float32=32.320000 --float64=64.640000" );
-	will_return( __wrap_os_system_run_wait, 0u );
-	will_return( __wrap_os_system_run_wait, "this is stdout" );
-	will_return( __wrap_os_system_run_wait, "this is stderr" );
-	will_return( __wrap_os_system_run_wait, IOT_STATUS_SUCCESS );
+	will_return( __wrap_os_system_run, 0u );
+	will_return( __wrap_os_system_run, "this is stdout" );
+	will_return( __wrap_os_system_run, "this is stderr" );
+	will_return( __wrap_os_system_run, IOT_STATUS_SUCCESS );
 #ifndef IOT_STACK_ONLY
 	/* add parameter: retval */
 	will_return( __wrap_os_realloc, 1 ); /* increase parameter array */
@@ -2836,12 +2837,12 @@ static void test_iot_action_process_command_parameter_int( void **state )
 	lib.request_queue_wait[0]->parameter[3].data.type = IOT_TYPE_INT64;
 	lib.request_queue_wait[0]->parameter[3].data.value.int64 = 64;
 	lib.request_queue_wait[0]->parameter[3].data.has_value = IOT_TRUE;
-	expect_string( __wrap_os_system_run_wait, command,
+	expect_string( __wrap_os_system_run, args->cmd,
 		"script_path --int8=8 --int16=16 --int32=32 --int64=64" );
-	will_return( __wrap_os_system_run_wait, 0u );
-	will_return( __wrap_os_system_run_wait, "this is stdout" );
-	will_return( __wrap_os_system_run_wait, "this is stderr" );
-	will_return( __wrap_os_system_run_wait, IOT_STATUS_SUCCESS );
+	will_return( __wrap_os_system_run, 0u );
+	will_return( __wrap_os_system_run, "this is stdout" );
+	will_return( __wrap_os_system_run, "this is stderr" );
+	will_return( __wrap_os_system_run, IOT_STATUS_SUCCESS );
 #ifndef IOT_STACK_ONLY
 	/* add parameter: retval */
 	will_return( __wrap_os_realloc, 1 ); /* increase parameter array */
@@ -2966,12 +2967,12 @@ static void test_iot_action_process_command_parameter_location( void **state )
 	lib.request_queue_wait[0]->parameter[0].data.heap_storage = loc;
 	lib.request_queue_wait[0]->parameter[0].data.value.location = loc;
 	lib.request_queue_wait[0]->parameter[0].data.has_value = IOT_TRUE;
-	expect_string( __wrap_os_system_run_wait, command,
+	expect_string( __wrap_os_system_run, args->cmd,
 		"script_path --param=[40.446195,-79.982195]" );
-	will_return( __wrap_os_system_run_wait, 0u );
-	will_return( __wrap_os_system_run_wait, "this is stdout" );
-	will_return( __wrap_os_system_run_wait, "this is stderr" );
-	will_return( __wrap_os_system_run_wait, IOT_STATUS_SUCCESS );
+	will_return( __wrap_os_system_run, 0u );
+	will_return( __wrap_os_system_run, "this is stdout" );
+	will_return( __wrap_os_system_run, "this is stderr" );
+	will_return( __wrap_os_system_run, IOT_STATUS_SUCCESS );
 #ifndef IOT_STACK_ONLY
 	/* add parameter: retval */
 	will_return( __wrap_os_realloc, 1 ); /* increase parameter array */
@@ -3081,11 +3082,12 @@ static void test_iot_action_process_command_parameter_null( void **state )
 	strncpy( lib.request_queue_wait[0]->parameter[0].name, "param", IOT_NAME_MAX_LEN );
 	lib.request_queue_wait[0]->parameter[0].data.type = IOT_TYPE_NULL;
 	lib.request_queue_wait[0]->parameter[0].data.has_value = IOT_TRUE;
-	expect_string( __wrap_os_system_run_wait, command, "script_path --param=[NULL]" );
-	will_return( __wrap_os_system_run_wait, 0u );
-	will_return( __wrap_os_system_run_wait, "this is stdout" );
-	will_return( __wrap_os_system_run_wait, "this is stderr" );
-	will_return( __wrap_os_system_run_wait, IOT_STATUS_SUCCESS );
+	expect_string( __wrap_os_system_run, args->cmd,
+		"script_path --param=[NULL]" );
+	will_return( __wrap_os_system_run, 0u );
+	will_return( __wrap_os_system_run, "this is stdout" );
+	will_return( __wrap_os_system_run, "this is stderr" );
+	will_return( __wrap_os_system_run, IOT_STATUS_SUCCESS );
 #ifndef IOT_STACK_ONLY
 	/* add parameter: retval */
 	will_return( __wrap_os_realloc, 1 ); /* increase parameter array */
@@ -3209,17 +3211,17 @@ static void test_iot_action_process_command_parameter_raw( void **state )
 #endif
 	lib.request_queue_wait[0]->parameter[0].data.has_value = IOT_TRUE;
 #ifdef IOT_STACK_ONLY
-	expect_string( __wrap_os_system_run_wait, command,
+	expect_string( __wrap_os_system_run, args->cmd,
 		"script_path --param=" );
 #else
 	will_return( __wrap_iot_base64_encode, 8u );
-	expect_string( __wrap_os_system_run_wait, command,
+	expect_string( __wrap_os_system_run, args->cmd,
 		"script_path --param=bbbbbbbb" );
 #endif
-	will_return( __wrap_os_system_run_wait, 0u );
-	will_return( __wrap_os_system_run_wait, "this is stdout" );
-	will_return( __wrap_os_system_run_wait, "this is stderr" );
-	will_return( __wrap_os_system_run_wait, IOT_STATUS_SUCCESS );
+	will_return( __wrap_os_system_run, 0u );
+	will_return( __wrap_os_system_run, "this is stdout" );
+	will_return( __wrap_os_system_run, "this is stderr" );
+	will_return( __wrap_os_system_run, IOT_STATUS_SUCCESS );
 #ifndef IOT_STACK_ONLY
 	/* add parameter: retval */
 	will_return( __wrap_os_realloc, 1 ); /* increase parameter array */
@@ -3349,12 +3351,12 @@ static void test_iot_action_process_command_parameter_string( void **state )
 	         "string\r\n \\ \"value\"",
 	         25 );
 	lib.request_queue_wait[0]->parameter[0].data.has_value = IOT_TRUE;
-	expect_string( __wrap_os_system_run_wait, command,
+	expect_string( __wrap_os_system_run, args->cmd,
 		"script_path --param=\"string \\\\ \\\"value\\\"\"" );
-	will_return( __wrap_os_system_run_wait, 0u );
-	will_return( __wrap_os_system_run_wait, "this is stdout" );
-	will_return( __wrap_os_system_run_wait, "this is stderr" );
-	will_return( __wrap_os_system_run_wait, IOT_STATUS_SUCCESS );
+	will_return( __wrap_os_system_run, 0u );
+	will_return( __wrap_os_system_run, "this is stdout" );
+	will_return( __wrap_os_system_run, "this is stderr" );
+	will_return( __wrap_os_system_run, IOT_STATUS_SUCCESS );
 #ifndef IOT_STACK_ONLY
 	/* add parameter: retval */
 	will_return( __wrap_os_realloc, 1 ); /* increase parameter array */
@@ -3493,11 +3495,11 @@ static void test_iot_action_process_command_parameter_string_max_len( void **sta
 		lib.request_queue_wait[0]->parameter[0].data.value.string,
 		lib.request_queue_wait[0]->parameter[0].data.value.string );
 	expected_path[ PATH_MAX ] = '\0';
-	expect_string( __wrap_os_system_run_wait, command, expected_path );
-	will_return( __wrap_os_system_run_wait, 0u );
-	will_return( __wrap_os_system_run_wait, "this is stdout" );
-	will_return( __wrap_os_system_run_wait, "this is stderr" );
-	will_return( __wrap_os_system_run_wait, IOT_STATUS_SUCCESS );
+	expect_string( __wrap_os_system_run, args->cmd, expected_path );
+	will_return( __wrap_os_system_run, 0u );
+	will_return( __wrap_os_system_run, "this is stdout" );
+	will_return( __wrap_os_system_run, "this is stderr" );
+	will_return( __wrap_os_system_run, IOT_STATUS_SUCCESS );
 #ifndef IOT_STACK_ONLY
 	/* add parameter: retval */
 	will_return( __wrap_os_realloc, 1 ); /* increase parameter array */
@@ -3629,12 +3631,12 @@ static void test_iot_action_process_command_parameter_uint( void **state )
 	lib.request_queue_wait[0]->parameter[3].data.type = IOT_TYPE_UINT64;
 	lib.request_queue_wait[0]->parameter[3].data.value.uint64 = 64u;
 	lib.request_queue_wait[0]->parameter[3].data.has_value = IOT_TRUE;
-	expect_string( __wrap_os_system_run_wait, command,
+	expect_string( __wrap_os_system_run, args->cmd,
 		"script_path --uint8=8 --uint16=16 --uint32=32 --uint64=64" );
-	will_return( __wrap_os_system_run_wait, 0u );
-	will_return( __wrap_os_system_run_wait, "this is stdout" );
-	will_return( __wrap_os_system_run_wait, "this is stderr" );
-	will_return( __wrap_os_system_run_wait, IOT_STATUS_SUCCESS );
+	will_return( __wrap_os_system_run, 0u );
+	will_return( __wrap_os_system_run, "this is stdout" );
+	will_return( __wrap_os_system_run, "this is stderr" );
+	will_return( __wrap_os_system_run, IOT_STATUS_SUCCESS );
 #ifndef IOT_STACK_ONLY
 	/* add parameter: retval */
 	will_return( __wrap_os_realloc, 1 ); /* increase parameter array */
@@ -3709,11 +3711,11 @@ static void test_iot_action_process_command_script_return_fail( void **state )
 	lib.request_queue_wait[0]->name = os_malloc( IOT_NAME_MAX_LEN + 1u );
 #endif
 	strncpy( lib.request_queue_wait[0]->name, "action name", IOT_NAME_MAX_LEN );
-	expect_string( __wrap_os_system_run_wait, command, "script_path" );
-	will_return( __wrap_os_system_run_wait, 1u ); /* script exit status */
-	will_return( __wrap_os_system_run_wait, "this is stdout" );
-	will_return( __wrap_os_system_run_wait, "this is stderr" );
-	will_return( __wrap_os_system_run_wait, IOT_STATUS_SUCCESS );
+	expect_string( __wrap_os_system_run, args->cmd, "script_path" );
+	will_return( __wrap_os_system_run, 1u ); /* script exit status */
+	will_return( __wrap_os_system_run, "this is stdout" );
+	will_return( __wrap_os_system_run, "this is stderr" );
+	will_return( __wrap_os_system_run, IOT_STATUS_SUCCESS );
 #ifndef IOT_STACK_ONLY
 	/* add parameter: retval */
 	will_return( __wrap_os_realloc, 1 ); /* increase parameter array */
@@ -3784,11 +3786,11 @@ static void test_iot_action_process_command_system_run_fail( void **state )
 	lib.request_queue_wait[0]->name = os_malloc( IOT_NAME_MAX_LEN + 1u );
 #endif
 	strncpy( lib.request_queue_wait[0]->name, "action name", IOT_NAME_MAX_LEN );
-	expect_string( __wrap_os_system_run_wait, command, "script_path" );
-	will_return( __wrap_os_system_run_wait, -1 );
-	will_return( __wrap_os_system_run_wait, "\0" );
-	will_return( __wrap_os_system_run_wait, "\0" );
-	will_return( __wrap_os_system_run_wait, IOT_STATUS_NOT_EXECUTABLE );
+	expect_string( __wrap_os_system_run, args->cmd, "script_path" );
+	will_return( __wrap_os_system_run, -1 );
+	will_return( __wrap_os_system_run, "\0" );
+	will_return( __wrap_os_system_run, "\0" );
+	will_return( __wrap_os_system_run, IOT_STATUS_NOT_EXECUTABLE );
 	will_return( __wrap_iot_plugin_perform, IOT_STATUS_SUCCESS );
 	result = iot_action_process( &lib, 0u );
 	assert_int_equal( result, IOT_STATUS_SUCCESS );
@@ -3846,11 +3848,11 @@ static void test_iot_action_process_command_valid( void **state )
 	lib.request_queue_wait[0]->name = os_malloc( IOT_NAME_MAX_LEN + 1u );
 #endif
 	strncpy( lib.request_queue_wait[0]->name, "action name", IOT_NAME_MAX_LEN );
-	expect_string( __wrap_os_system_run_wait, command, "script_path" );
-	will_return( __wrap_os_system_run_wait, 0u );
-	will_return( __wrap_os_system_run_wait, "this is stdout" );
-	will_return( __wrap_os_system_run_wait, "this is stderr" );
-	will_return( __wrap_os_system_run_wait, IOT_STATUS_SUCCESS );
+	expect_string( __wrap_os_system_run, args->cmd, "script_path" );
+	will_return( __wrap_os_system_run, 0u );
+	will_return( __wrap_os_system_run, "this is stdout" );
+	will_return( __wrap_os_system_run, "this is stderr" );
+	will_return( __wrap_os_system_run, IOT_STATUS_SUCCESS );
 #ifndef IOT_STACK_ONLY
 	/* add parameter: retval */
 	will_return( __wrap_os_realloc, 1 ); /* increase parameter array */

--- a/test/unit/mock/mock_osal.c
+++ b/test/unit/mock/mock_osal.c
@@ -77,22 +77,7 @@ unsigned long __wrap_os_strtoul( const char *str, char **endptr );
 int __wrap_os_system_error_last( void );
 const char *__wrap_os_system_error_string( int error_number );
 os_uint32_t __wrap_os_system_pid( void );
-os_status_t __wrap_os_system_run(
-	const char *command,
-	int *exit_status,
-	os_bool_t privileged,
-	int priority,
-	size_t stack_size,
-	os_file_t pipe_files[2u] );
-os_status_t __wrap_os_system_run_wait(
-	const char *command,
-	int *exit_status,
-	os_bool_t privileged,
-	int priority,
-	size_t stack_size,
-	char *out_buf[2u],
-	size_t out_len[2u],
-	os_millisecond_t max_time_out );
+os_status_t __wrap_os_system_run( os_system_run_args_t *args );
 os_bool_t __wrap_os_terminal_vt100_support( os_file_t stream );
 #ifdef IOT_THREAD_SUPPORT
 os_status_t __wrap_os_thread_condition_broadcast( os_thread_condition_t *cond );
@@ -673,46 +658,27 @@ os_uint32_t __wrap_os_system_pid( void )
 }
 
 os_status_t __wrap_os_system_run(
-	const char *command,
-	int *exit_status,
-	os_bool_t privileged,
-	int priority,
-	size_t stack_size,
-	os_file_t pipe_files[2u] )
+	os_system_run_args_t *args )
 {
+	char *std_err;
+	char *std_out;
 	/* ensure this function is called meeting pre-requirements */
-	assert_non_null( command );
-	check_expected( command );
-	assert_non_null( exit_status );
+	assert_non_null( args );
+	assert_non_null( args->cmd );
+	check_expected( args->cmd );
 
-	if ( exit_status )
-		*exit_status = mock_type( int );
-	return mock_type( os_status_t );
-}
-
-os_status_t __wrap_os_system_run_wait(
-	const char *command,
-	int *exit_status,
-	os_bool_t privileged,
-	int priority,
-	size_t stack_size,
-	char *out_buf[2u],
-	size_t out_len[2u],
-	os_millisecond_t max_time_out )
-{
-	/* ensure this function is called meeting pre-requirements */
-	assert_non_null( command );
-	check_expected( command );
-	assert_non_null( exit_status );
-	assert_non_null( out_buf );
-	assert_non_null( out_len );
-
-	if ( exit_status )
-		*exit_status = mock_type( int );
-	if ( out_buf[0u] )
-		strncpy( out_buf[0u], mock_type( char * ), out_len[0u] );
-	if ( out_buf[1u] )
-		strncpy( out_buf[1u], mock_type( char * ), out_len[1u] );
+	args->return_code = mock_type( int );
+	std_out = mock_type( char * );
+	std_err = mock_type( char * );
+	if ( args->block == OS_TRUE )
+	{
+		if ( args->opts.block.std_out.buf && std_out )
+			strncpy( args->opts.block.std_out.buf,
+				std_out, args->opts.block.std_out.len );
+		if ( args->opts.block.std_err.buf && std_err )
+			strncpy( args->opts.block.std_err.buf,
+				std_err, args->opts.block.std_err.len );
+	}
 	return mock_type( os_status_t );
 }
 

--- a/test/unit/mock/mock_osal.cmake
+++ b/test/unit/mock/mock_osal.cmake
@@ -63,7 +63,6 @@ set( MOCK_OSAL_FUNC
 	"os_system_error_string"
 	"os_system_pid"
 	"os_system_run"
-	"os_system_run_wait"
 	"os_terminal_vt100_support"
 	"os_thread_condition_broadcast"
 	"os_thread_condition_create"


### PR DESCRIPTION
This patch updates the source code to use the new `os_system_run`
signature that was updated in the OSAL layer.  This will help to
integrate better across multiple platforms.

Signed-off-by: Keith Holman <keith.holman@windriver.com>

[NOTE BUILD WILL FAIL BECAUSE OF CHANGE IN OSAL SIGNATURE!]