### PR TITLE
android: do not run system commands as priviledged

### DIFF
--- a/src/device-manager/device_manager_main.c
+++ b/src/device-manager/device_manager_main.c
@@ -1662,7 +1662,7 @@ iot_status_t device_manager_run_os_command( const char *cmd,
 				out_len[i] = 0u;
 			}
 		}
-		if ( os_system_run_wait( cmd, &retval, OS_TRUE, 0, 0u,
+		if ( os_system_run_wait( cmd, &retval, OS_FALSE, 0, 0u,
 			out_buf, out_len, 0u ) == IOT_STATUS_SUCCESS &&
 			     retval >= 0 )
 			result = IOT_STATUS_SUCCESS;


### PR DESCRIPTION
fixes: #133

On Android there is not such thing as the "sudo" command.  Running an
operating system command as privileged attempts to run commands by
prefixing "sudo".  This patch indicates not the run the operating system
command code in privileged mode, thus removing the addition of "sudo" to
the command.

Signed-off-by: Keith Holman <keith.holman@windriver.com>