### PR TITLE
vxworks: fixes to build on VxWorks 7

### DIFF
--- a/build-sys/vxworks-lib/control/Makefile
+++ b/build-sys/vxworks-lib/control/Makefile
@@ -14,7 +14,7 @@
 
 ifeq ($(SPACE), user)
 EXE = iot-control
-ADDED_LIBS += -liotutils -lm -losal -lnet -larchive -lHASH -lOPENSSL -lmosquitto -ljson -lzlib -lcurl -lunix
+ADDED_LIBS += -liot -losal -lnet -larchive -lHASH -lOPENSSL -lmosquitto -ljson -lzlib -lcurl -lunix
 else
 LIB_BASE_NAME = deviceCloudControl
 endif

--- a/build-sys/vxworks-lib/device-manager/Makefile
+++ b/build-sys/vxworks-lib/device-manager/Makefile
@@ -14,7 +14,7 @@
 
 ifeq ($(SPACE), user)
 EXE = iot-device-manager
-ADDED_LIBS += -liot -liotutils -losal -lnet -larchive -lHASH -lOPENSSL -lmosquitto -ljson -lzlib -lcurl -lunix
+ADDED_LIBS += -liot -losal -lnet -larchive -lHASH -lOPENSSL -lmosquitto -ljson -lzlib -lcurl -lunix
 else
 LIB_BASE_NAME = deviceCloudManager
 endif

--- a/build-sys/vxworks-lib/lib/vxworks.krnl.mak
+++ b/build-sys/vxworks-lib/lib/vxworks.krnl.mak
@@ -45,12 +45,16 @@ SRC_FILES = \
         $(DEVICE_CLOUD_LIB_DIR)/src/api/json/iot_json_base.c \
         $(DEVICE_CLOUD_LIB_DIR)/src/api/json/iot_json_decode.c \
         $(DEVICE_CLOUD_LIB_DIR)/src/api/json/iot_json_encode.c \
-        $(DEVICE_CLOUD_LIB_DIR)/src/api/json/iot_json_schema.c \
         $(DEVICE_CLOUD_LIB_DIR)/src/api/checksum/iot_checksum.c \
         $(DEVICE_CLOUD_LIB_DIR)/src/api/checksum/iot_checksum_crc32.c \
         $(DEVICE_CLOUD_LIB_DIR)/src/api/plugin/iot_plugin_builtin.c \
         $(DEVICE_CLOUD_LIB_DIR)/src/api/plugin/tr50/tr50.c \
         $(DEVICE_CLOUD_LIB_DIR)/src/utilities/app_arg.c \
+        $(DEVICE_CLOUD_LIB_DIR)/src/utilities/app_config.c \
+        $(DEVICE_CLOUD_LIB_DIR)/src/utilities/app_json_base.c \
+        $(DEVICE_CLOUD_LIB_DIR)/src/utilities/app_json_decode.c \
+        $(DEVICE_CLOUD_LIB_DIR)/src/utilities/app_json_encode.c \
+        $(DEVICE_CLOUD_LIB_DIR)/src/utilities/app_json_schema.c \
         $(DEVICE_CLOUD_LIB_DIR)/src/utilities/app_log.c \
         $(DEVICE_CLOUD_LIB_DIR)/src/utilities/app_path.c \
         $(DEVICE_CLOUD_LIB_DIR)/build-sys/vxworks-lib/vxworks_lib.c

--- a/build-sys/vxworks-lib/lib/vxworks.lib.mak
+++ b/build-sys/vxworks-lib/lib/vxworks.lib.mak
@@ -46,12 +46,16 @@ SRC_FILES = \
         $(DEVICE_CLOUD_LIB_DIR)/src/api/json/iot_json_base.c \
         $(DEVICE_CLOUD_LIB_DIR)/src/api/json/iot_json_decode.c \
         $(DEVICE_CLOUD_LIB_DIR)/src/api/json/iot_json_encode.c \
-        $(DEVICE_CLOUD_LIB_DIR)/src/api/json/iot_json_schema.c \
         $(DEVICE_CLOUD_LIB_DIR)/src/api/checksum/iot_checksum.c \
         $(DEVICE_CLOUD_LIB_DIR)/src/api/checksum/iot_checksum_crc32.c \
         $(DEVICE_CLOUD_LIB_DIR)/src/api/plugin/iot_plugin_builtin.c \
         $(DEVICE_CLOUD_LIB_DIR)/src/api/plugin/tr50/tr50.c \
         $(DEVICE_CLOUD_LIB_DIR)/src/utilities/app_arg.c \
+        $(DEVICE_CLOUD_LIB_DIR)/src/utilities/app_config.c \
+        $(DEVICE_CLOUD_LIB_DIR)/src/utilities/app_json_base.c \
+        $(DEVICE_CLOUD_LIB_DIR)/src/utilities/app_json_decode.c \
+        $(DEVICE_CLOUD_LIB_DIR)/src/utilities/app_json_encode.c \
+        $(DEVICE_CLOUD_LIB_DIR)/src/utilities/app_json_schema.c \
         $(DEVICE_CLOUD_LIB_DIR)/src/utilities/app_log.c \
         $(DEVICE_CLOUD_LIB_DIR)/src/utilities/app_path.c \
         $(DEVICE_CLOUD_LIB_DIR)/build-sys/vxworks-lib/vxworks_lib.c

--- a/build-sys/vxworks-lib/relay/Makefile
+++ b/build-sys/vxworks-lib/relay/Makefile
@@ -14,7 +14,7 @@
 
 ifeq ($(SPACE), user)
 EXE = iot-relay
-ADDED_LIBS += -liotutils -lm -losal -lnet -lcivetweb -larchive -lHASH -lOPENSSL -lmosquitto -ljson -lzlib -lcurl -lunix
+ADDED_LIBS += -liot -losal -lnet -lcivetweb -larchive -lHASH -lOPENSSL -lmosquitto -ljson -lzlib -lcurl -lunix
 else
 LIB_BASE_NAME = deviceCloudRelay
 endif


### PR DESCRIPTION
This patch updates the build scripts to build again for VxWorks 7.
Recent commits didn't update the build system for VxWorks.

Signed-off-by: Keith Holman <keith.holman@windriver.com>