### PR TITLE
Relay cert

### DIFF
--- a/src/api/plugin/tr50/tr50.c
+++ b/src/api/plugin/tr50/tr50.c
@@ -2716,7 +2716,11 @@ iot_status_t tr50_terminate(
 #ifdef IOT_THREAD_SUPPORT
 	os_thread_mutex_destroy( &data->mail_check_mutex );
 #endif /* IOT_THREAD_SUPPORT */
-	os_free_null( (void**)&data );
+	if ( data )
+	{
+		os_free( data );
+		data = NULL;
+	}
 	iot_mqtt_terminate();
 	curl_global_cleanup();
 	return result;

--- a/src/device-manager/device_manager_main.h
+++ b/src/device-manager/device_manager_main.h
@@ -47,9 +47,6 @@
 /** @brief Flag to enable remote login related actions */
 #define DEVICE_MANAGER_ENABLE_REMOTE_LOGIN            0x0100
 
-/** @brief Remote login protocol maximum length */
-#define REMOTE_LOGIN_PROTOCOL_MAX 32
-
 /**
  * @brief Index of various default device manager functions in the global
  *        structure
@@ -67,7 +64,6 @@ enum device_manager_config_idx
 	DEVICE_MANAGER_IDX_FILE_UPLOAD,
 	DEVICE_MANAGER_IDX_PING,
 	DEVICE_MANAGER_IDX_REMOTE_LOGIN,
-	DEVICE_MANAGER_IDX_REMOTE_LOGIN_PROTOCOL,
 	DEVICE_MANAGER_IDX_RESTORE_FACTORY_IMAGES,
 	DEVICE_MANAGER_IDX_SOFTWARE_UPDATE,
 
@@ -91,10 +87,10 @@ struct device_manager_info
 {
 	/** @brief Library handle */
 	iot_t *iot_lib;
-#ifndef NO_FILEIO_SUPPORT
+#if !defined( NO_FILEIO_SUPPORT )
 	/** @brief structure used to support file input/output operations */
 	struct device_manager_file_io_info file_io_info;
-#endif
+#endif /* if !defined( NO_FILEIO_SUPPORT ) */
 	/** @brief registered device manager actions */
 	struct device_manager_action actions[DEVICE_MANAGER_IDX_LAST];
 	/** @brief agent_state */
@@ -103,8 +99,6 @@ struct device_manager_info
 	char app_path[PATH_MAX + 1u];
 	/** @brief run time directory */
 	char runtime_dir[PATH_MAX + 1u];
-	/** @brief valid remote login protocols */
-	iot_json_encoder_t* remote_login_protocols;
 	/** @brief number of loops main loop has gone through */
 	size_t loop_count;
 	/** @brief log level */

--- a/src/device-manager/iot.cfg.example
+++ b/src/device-manager/iot.cfg.example
@@ -13,10 +13,10 @@
 		"remote_login" : true
 	},
 	"remote_access_support":[
-		{ "name": "Telnet", "port":"23", "session_timeout":"120" },
-		{ "name": "SSH",    "port":"22", "session_timeout":"120" },
+		{ "name": "Telnet", "port":"telnet", "session_timeout":120 },
+		{ "name": "SSH",    "port":"ssh", "session_timeout":120 },
 		{ "name": "VNC",    "port":"5900" },
-		{ "name": "HTTP",   "port":"80" },
+		{ "name": "HTTP",   "port":"http" },
 		{ "name": "RDP",    "port":"3389" }
 	]
 }

--- a/src/relay/CMakeLists.txt
+++ b/src/relay/CMakeLists.txt
@@ -34,12 +34,6 @@ include_directories( SYSTEM
 	${OPENSSL_INCLUDE_DIR}
 )
 
-# Local include directories
-include_directories(
-	"../api"
-	"../utilities"
-)
-
 # Executable files
 add_executable( ${TARGET}
 	${IOT_HDRS_C}
@@ -52,12 +46,9 @@ add_executable( ${TARGET}
 # Required libraries
 target_link_libraries( ${TARGET}
 	iotutils
-	${JSON_LIBRARIES}
 	${WEBSOCKET_LIBRARIES}
-	${OPENSSL_LIBRARIES}
 	${OSAL_LIBRARIES}
 	${CMAKE_THREAD_LIBS_INIT}
-	${CMAKE_DL_LIBS} "m"
 )
 
 # Installation instructions

--- a/src/utilities/app_json_base.c
+++ b/src/utilities/app_json_base.c
@@ -20,13 +20,13 @@
 
 #include <os.h>
 
-#ifndef IOT_STACK_ONLY
+#if !defined( IOT_STACK_ONLY )
 /** @brief internal pointer to use for freeing dynamically allocated memory */
 static app_json_free_t *JSON_FREE = NULL;
 /** @brief internal pointer to use for dynamically allocating memory */
 static app_json_realloc_t *JSON_REALLOC = NULL;
 
-#ifdef IOT_JSON_JANSSON
+#if defined( IOT_JSON_JANSSON )
 /**
  * @brief helper function to dynamically allocate memory for JSON
  *
@@ -57,7 +57,7 @@ static void app_jansson_free( void *p )
 	else
 		os_free( p );
 }
-#endif /* ifdef IOT_JSON_JANSSON */
+#endif /* if defined( IOT_JSON_JANSSON ) */
 
 void app_json_allocation_get( app_json_realloc_t **mptr, app_json_free_t **fptr )
 {
@@ -69,9 +69,9 @@ void app_json_allocation_get( app_json_realloc_t **mptr, app_json_free_t **fptr 
 
 void app_json_allocation_set( app_json_realloc_t* mptr, app_json_free_t* fptr )
 {
-#ifdef IOT_JSON_JANSSON
+#if defined( IOT_JSON_JANSSON )
 	json_set_alloc_funcs( app_jansson_malloc, app_jansson_free );
-#endif /* ifdef IOT_JSON_JANSSON */
+#endif /* if defined( IOT_JSON_JANSSON ) */
 	JSON_REALLOC = mptr;
 	JSON_FREE = fptr;
 }
@@ -91,4 +91,4 @@ void app_json_free( void* ptr )
 	else
 		os_free(ptr);
 }
-#endif /* ifndef IOT_STACK_ONLY */
+#endif /* if !defined( IOT_STACK_ONLY ) */


### PR DESCRIPTION
This patch set contains multiple fixes.

1) Certificate information is now passed via the command line when calling `iot-relay`.  This is useful, if the device manager is configured to use private certificates.  In this major, `iot-relay` will also use the same private certificate when connecting with the cloud.  Previously, `iot-relay` was trying to read this information from `/etc/iot/iot-connect.cfg`.  However, if the private certificate was specified in `/etc/iot/device-manager.cfg`, the `iot-relay` wouldn't pick up the new path.

2) Memory leak fixes.  There we memory leak fixes throughout the `iot-device-manager` that are fixes.  When running under Linux & Valgrind, it now shows 0 memory leaks.

3) General code clean-up.  The relay_client (the main method inside `iot-relay) app, now passes function arguments as a structure.  This makes it easier to pass more functions to this method without bloating the command line.

4)  There is now a method added to `iot-device-manager` to re-read the ports from the configuration file and test them.  This is similar to the functionality provided by the python device-manager.  This further aligns with using the same thing definition for both products.

5) Now, you are able to specify a "service name" (as defined in `/etc/services`) instead of port in your `iot.cfg` for the `iot-device-manager`.  The device manager will now parse this file for the port number and use that to publish.  This allows for not having to know port numbers and use them by name on the devices.  This change was also forwarded to `iot-relay` but due to cloud limitations currently only port numbers are passed down (and not service names).
